### PR TITLE
Fix docker builds: pin pnpm 9, supply client build-time URL

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -20,6 +20,11 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# NEXT_PUBLIC_* variables are inlined at build time; the client's env loader
+# fails the build when the variable is missing.
+ARG NEXT_PUBLIC_SERVER_URL
+ENV NEXT_PUBLIC_SERVER_URL=$NEXT_PUBLIC_SERVER_URL
+
 # Uncomment the following line in case you want to disable telemetry during the build.
 # ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_PRIVATE_STANDALONE=true

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "subvision-client",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
     build:
       context: ./client
       dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_SERVER_URL: ${NEXT_PUBLIC_SERVER_URL:-http://localhost:8080}
     container_name: subvision-client
     ports:
       - "3000:3000"

--- a/vfx/Dockerfile
+++ b/vfx/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 
-RUN corepack prepare pnpm@latest --activate && pnpm install --frozen-lockfile
+RUN corepack prepare pnpm@9.15.9 --activate && pnpm install --frozen-lockfile
 
 COPY . .
 

--- a/vfx/package.json
+++ b/vfx/package.json
@@ -1,6 +1,7 @@
 {
   "name": "subvision-vfx",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "version": "0.0.0",
   "scripts": {
     "dev": "concurrently \"nodemon\" \"pnpm dlx @tailwindcss/cli -i ./src/styles/tailwind.css -o ./dist/styles/tailwind.css --watch\"",


### PR DESCRIPTION
`docker-compose up --build` fails in the vfx image, and would next fail in the client image. Two independent causes:

**vfx: `corepack prepare pnpm@latest --activate`** now resolves to pnpm 10, which exits 1 on dependency build scripts it isn't told to allow (`ERR_PNPM_IGNORED_BUILDS`: esbuild, @tailwindcss/oxide, @parcel/watcher). Both lockfiles are lockfileVersion 9.0, produced by pnpm 9.15.9 — so the fix is to pin, not to chase latest:

- `packageManager: "pnpm@9.15.9"` declared in both `vfx/package.json` and `client/package.json`, so corepack uses the lockfile's toolchain everywhere.
- The vfx Dockerfile pins `corepack prepare pnpm@9.15.9` instead of `@latest`.

**client: `NEXT_PUBLIC_SERVER_URL` at build time.** Since the env contract landed (fail-loud loaders, no silent defaults), `next build` evaluates the client's env loader and throws when the variable is missing — and NEXT_PUBLIC_* values are inlined at build time, so the Dockerfile must receive it. The builder stage now takes `ARG NEXT_PUBLIC_SERVER_URL`, and compose passes it with the documented default (`${NEXT_PUBLIC_SERVER_URL:-http://localhost:8080}`), overridable from the host environment.

Verified locally: vfx typecheck + 39 tests green, client `tsc --noEmit` green, server `go build` + tests green on this tree.