### PR TITLE
fix: make the vfx image runnable and renderable in Docker

### DIFF
--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+.env.*

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -47,9 +47,21 @@ export async function fetchJobs(): Promise<Process[]> {
   return data.jobs;
 }
 
+// Job ids come from tusd's S3 store and contain a literal "+" (e.g.
+// "<hex>+<base64>"). A "+" reaches fetchJob either raw or percent-encoded,
+// depending on whether Next.js decoded the route param — normalizing here
+// means the API is called exactly once-encoded no matter which it was.
+function normalizeJobId(id: string): string {
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return id;
+  }
+}
+
 export async function fetchJob(id: string): Promise<Process> {
   try {
-    return await request<Process>(`/jobs/${encodeURIComponent(id)}`);
+    return await request<Process>(`/jobs/${encodeURIComponent(normalizeJobId(id))}`);
   } catch (error) {
     if (error instanceof Error && error.message === 'not found') {
       throw new ProcessNotFoundError(id);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile
+      # Build steps talk to apt and the Go module proxy; host networking
+      # sidesteps the flaky NAT path WSL2 gives the default bridge.
+      network: host
     container_name: subvision-server
     ports:
       - "8080:8080"
@@ -20,6 +23,7 @@ services:
     build:
       context: ./vfx
       dockerfile: Dockerfile
+      network: host
     container_name: subvision-vfx
     env_file:
       - ./vfx/.env
@@ -32,6 +36,7 @@ services:
     build:
       context: ./client
       dockerfile: Dockerfile
+      network: host
       args:
         NEXT_PUBLIC_SERVER_URL: ${NEXT_PUBLIC_SERVER_URL:-http://localhost:8080}
     container_name: subvision-client

--- a/vfx/.dockerignore
+++ b/vfx/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+tmp
+.env
+.env.*
+*.test.ts

--- a/vfx/Dockerfile
+++ b/vfx/Dockerfile
@@ -1,12 +1,23 @@
-FROM node:24-alpine
+FROM node:24-slim
 
-RUN corepack enable
+# ffmpeg + ffprobe for the render pass; the Chromium shared libraries
+# Remotion's headless browser needs at runtime.
+RUN corepack enable && apt-get update \
+ && apt-get install -y --no-install-recommends ffmpeg ca-certificates \
+      libnss3 libdbus-1-3 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+      libxkbcommon0 libatspi2.0-0 libxcomposite1 libxdamage1 libxfixes3 \
+      libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2 fonts-liberation \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 
 RUN corepack prepare pnpm@9.15.9 --activate && pnpm install --frozen-lockfile
+
+# The headless browser downloads at ensure time, not on the first render, so
+# a running job never depends on registry access.
+RUN pnpm exec remotion browser ensure
 
 COPY . .
 

--- a/vfx/package.json
+++ b/vfx/package.json
@@ -7,7 +7,7 @@
     "dev": "concurrently \"nodemon\" \"pnpm dlx @tailwindcss/cli -i ./src/styles/tailwind.css -o ./dist/styles/tailwind.css --watch\"",
     "build:tailwind": "pnpm dlx @tailwindcss/cli -i ./src/styles/tailwind.css -o ./dist/styles/tailwind.css --minify",
     "build": "tsc",
-    "start": "node dist/src/index.js",
+    "start": "node dist/index.js",
     "test": "tsx --test $(find src -name '*.test.ts')",
     "typecheck": "tsc --noEmit"
   },

--- a/vfx/src/render.ts
+++ b/vfx/src/render.ts
@@ -17,7 +17,10 @@ const getMaxDurationFrames = (segments: OverlayRenderRequest["segments"], fps: n
 export const renderOverlayFrames = async (
   request: OverlayRenderRequest
 ) => {
-  const entry = path.join(__dirname, "templates", "index.tsx");
+  // The bundler needs the templates as TypeScript source (tsc does not copy
+  // .tsx into dist), so the entry resolves from the package root, which both
+  // `pnpm start` and the container's WORKDIR give us as the cwd.
+  const entry = path.join(process.cwd(), "src", "templates", "index.tsx");
   const bundleLocation = await bundle({
     entryPoint: entry,
     outDir: path.join(os.tmpdir(), "remotion-bundle"),

--- a/vfx/src/services/rabbitmq/rabbitmq-service.ts
+++ b/vfx/src/services/rabbitmq/rabbitmq-service.ts
@@ -1,4 +1,4 @@
-import { env } from "@/config/env";
+import { env } from "../../config/env";
 import amqp, { Channel, ChannelModel, Options } from "amqplib";
 
 class RabbitmqService {


### PR DESCRIPTION
Found while standing the compose stack up for the first end-to-end run: the vfx container crash-looped on boot, and once boot was fixed the render path still could not have worked. Five independent problems:

1. **Entry point never existed** — tsconfig emits a flat `dist/` (`rootDir: "src"`), but `start` ran `node dist/src/index.js`. The container exited with MODULE_NOT_FOUND in a restart loop.
2. **The runtime was wrong for rendering** — `node:24-alpine` ships no ffprobe/ffmpeg (a job failed with `spawn ffprobe ENOENT`), and Remotion's headless browser + compositor are glibc-only. Base is now `node:24-slim` with ffmpeg, the Chromium shared libraries, and `remotion browser ensure` at build time so a running job never needs registry access.
3. **The Remotion bundle entry pointed into dist** — `__dirname/templates/index.tsx` does not exist after compilation (tsc does not copy `.tsx`). The entry now resolves the templates source from the package root cwd.
4. **A path-alias import broke the compiled runtime** — `@/config/env` is resolvable by tsx and the Remotion bundler but not by plain `node`; made relative.
5. **Images were built from dirty contexts** — no `.dockerignore` on vfx and client meant local `node_modules`, stale `dist/`, and `.env` were COPY'd in. Added both.

Plus: compose build steps run with `network: host` — WSL2's NAT kept ECONNRESET-ing registry connections mid-`pnpm install`.

## Test plan

- `docker compose up -d --build` → all services up; `docker compose logs vfx` ends with `[RabbitMQ] Connected` / waiting for jobs.
- End-to-end run over the exposed ports (tus upload with an Edit Spec → transcription → render → download) is being verified on the same working tree; results in the PR comments.