### PR TITLE
fix: wait for broker readiness before starting server and vfx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,10 @@ services:
       - ./server/data:/app/data
     restart: always
     depends_on:
-      - rabbitmq
-      - rustfs
+      rabbitmq:
+        condition: service_healthy
+      rustfs:
+        condition: service_healthy
 
   vfx:
     build:
@@ -29,8 +31,10 @@ services:
       - ./vfx/.env
     restart: always
     depends_on:
-      - rabbitmq
-      - rustfs
+      rabbitmq:
+        condition: service_healthy
+      rustfs:
+        condition: service_healthy
 
   client:
     build:
@@ -77,6 +81,11 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: guest
       RABBITMQ_DEFAULT_PASS: guest
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
 
   createbuckets:
     image: amazon/aws-cli:latest


### PR DESCRIPTION
Plain depends_on only orders container starts, so on every cold start server and vfx raced RabbitMQ boot and crash-looped on ECONNREFUSED until broker came up.

- Add rabbitmq healthcheck (rabbitmq-diagnostics -q ping, interval 5s, retries 12)
- Gate server and vfx on rabbitmq: service_healthy (rustfs already had healthcheck, now also gated explicitly)

Carries 5502281 on fix/vfx-docker-image. Follow-up to PR #12.