### PR TITLE
fix(client): remove AI slop from user-facing copy

### DIFF
--- a/client/app/editor/page.tsx
+++ b/client/app/editor/page.tsx
@@ -115,7 +115,7 @@ function Editor() {
         }
         toast({
           title: 'Upload complete',
-          description: 'Your video is in the pipeline — watch it in the gallery.',
+          description: 'Your video is in the pipeline. Watch it in the gallery.',
         });
         router.push(`/processes/${fileId}`);
       },
@@ -134,7 +134,7 @@ function Editor() {
             That video is no longer in this session
           </h1>
           <p className="mt-2 text-sm text-muted-foreground">
-            The editor keeps your selection in memory only — pick the video
+            The editor keeps your selection in memory only. Pick the video
             again to start fresh.
           </p>
           <Button asChild className="mt-6">

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -56,7 +56,7 @@ export default function Home() {
           </h1>
           <p className="mx-auto mt-5 max-w-xl text-balance text-lg text-muted-foreground">
             Pick a video, trim it, frame it for any platform, and style your
-            captions. Subvision transcribes and burns everything in — you just
+            captions. Subvision transcribes and burns everything in. You just
             download the result.
           </p>
         </div>
@@ -112,10 +112,10 @@ export default function Home() {
             )}
           </span>
           <p className="mt-5 font-display text-xl font-semibold">
-            {dragging ? 'Drop it — let’s caption it' : 'Drop a video here'}
+            {dragging ? 'Drop it. Let’s caption it' : 'Drop a video here'}
           </p>
           <p className="mt-1.5 text-sm text-muted-foreground">
-            or click to browse — MP4, MOV, AVI, MKV, WebM, up to 500 MB
+            or click to browse: MP4, MOV, AVI, MKV, WebM, up to 500 MB
           </p>
           <Button size="lg" className="mt-6 pointer-events-none">
             <FileVideo2 className="h-4 w-4" />
@@ -133,7 +133,7 @@ export default function Home() {
             {
               icon: Sparkles,
               title: 'Style the captions',
-              body: 'Fonts, outline, highlight swipes — previewed live before a single frame renders.',
+              body: 'Fonts, outline, highlight swipes, previewed live before a single frame renders.',
             },
             {
               icon: Clapperboard,

--- a/client/app/processes/page.tsx
+++ b/client/app/processes/page.tsx
@@ -8,7 +8,7 @@ export default function ProcessesPage() {
         <div className="mb-6">
           <h1 className="font-display text-3xl font-bold tracking-tight">Gallery</h1>
           <p className="mt-1.5 text-muted-foreground">
-            Every video you have captioned — hover a finished one to preview it.
+            Every video you have captioned. Hover a finished one to preview it.
           </p>
         </div>
         <ProcessGallery />

--- a/client/components/editor/animation-picker.tsx
+++ b/client/components/editor/animation-picker.tsx
@@ -34,7 +34,7 @@ export function AnimationPicker({ value, onChange, disabled }: AnimationPickerPr
                   : 'border-border bg-card text-muted-foreground hover:border-primary/40 hover:text-foreground'
               }`}
             >
-              {option.value === 'random' ? 'Random 🎲' : option.label}
+              {option.value === 'random' ? 'Random' : option.label}
             </button>
           );
         })}

--- a/client/components/editor/frame-picker.tsx
+++ b/client/components/editor/frame-picker.tsx
@@ -75,7 +75,7 @@ export function FramePicker({ frame, onChange, disabled }: FramePickerProps) {
         </div>
         {frame.preset === 'free' && (
           <p className="mt-2 text-xs text-muted-foreground">
-            Drag the handle in the preview’s corner to set any ratio — currently{' '}
+            Drag the handle in the preview’s corner to set any ratio. Currently{' '}
             <span className="font-medium text-foreground">{ratioLabel}</span>.
           </p>
         )}

--- a/client/components/process-details.tsx
+++ b/client/components/process-details.tsx
@@ -178,7 +178,7 @@ export function ProcessDetails({ processId }: { processId: string }) {
             {STAGE_LABEL[process.stage]}…
           </p>
           <p className="mt-1.5 text-sm text-muted-foreground">
-            This page updates itself — no need to refresh.
+            This page updates itself. No need to refresh.
           </p>
         </Card>
       ) : null}

--- a/client/hooks/use-process-polling.ts
+++ b/client/hooks/use-process-polling.ts
@@ -65,7 +65,7 @@ export function useProcess(id: string) {
       } catch (err) {
         if (cancelled) return;
         if (err instanceof ProcessNotFoundError) {
-          // A 404 right after the upload may simply mean the server hasn't
+          // A 404 right after the upload may mean the server hasn't
           // recorded the process yet; retry briefly before giving up.
           unknownAttempts += 1;
           if (unknownAttempts >= 15) {

--- a/client/lib/edit-spec.ts
+++ b/client/lib/edit-spec.ts
@@ -72,7 +72,7 @@ export const ANIMATION_OPTIONS: Array<{ value: AnimationChoice; label: string; h
   { value: 'slide', label: 'Slide', hint: 'Glides in from the left and settles.' },
   { value: 'karaoke', label: 'Karaoke', hint: 'A highlight swipes across each word as it is spoken.' },
   { value: 'pop', label: 'Pop', hint: 'Shorts-style: words pop in one by one with the active word lit up.' },
-  { value: 'random', label: 'Random', hint: 'Roll the dice — one of the four is picked when you generate.' },
+  { value: 'random', label: 'Random', hint: 'Roll the dice. One of the four is picked when you generate.' },
 ];
 
 export const COLOR_SWATCHES = [


### PR DESCRIPTION
## What

Cleans AI slop from client UI copy. Verified against `no-ai-slop` skill eval — codebase was already clean; this is the remaining low-risk polish.

## Changes

- Em dashes `—` → periods/colons in 7 user-facing strings:
  - `app/page.tsx`: hero blurb, dropzone drag text, browse hint, Style feature card
  - `app/processes/page.tsx`: gallery subtitle
  - `app/editor/page.tsx`: success toast, missing-video notice
  - `components/process-details.tsx`: "This page updates itself. No need to refresh."
  - `components/editor/frame-picker.tsx`: free-ratio helper
  - `lib/edit-spec.ts`: Random hint "Roll the dice. One of the four…"
- `hooks/use-process-polling.ts`: cut filler adverb `simply`
- `components/editor/animation-picker.tsx`: remove decorative `🎲` from Random chip (formatting slop)

No behavior change. Remaining `—` in code comments, `CONTEXT.md`/`.scratch` docs, and the `Subvision — AI subtitles…` title are intentional.

## Verify

- `pnpm -C client build` — pass (Next.js 15.2.4, 6 pages, compiled successfully)
- Manual grep: banned words/phrases 0 hits, binary contrasts / throat-clearing / puffery / weasel / kicker 0 hits
- 8 files, 12 insertions(+), 12 deletions(-)

## How to test

No functional change. Open `/`, `/editor`, `/processes`, `/processes/[id]` and confirm copy reads the same without `—`/`🎲`.