### PR TITLE
feat: delete processes from the gallery

### DIFF
--- a/.scratch/architecture-review/issues/01-reconnect-vfx-job-handoff.md
+++ b/.scratch/architecture-review/issues/01-reconnect-vfx-job-handoff.md
@@ -1,0 +1,24 @@
+# 01 — reconnect-vfx-job-handoff
+
+**GitHub issue:** #2
+
+**Status:** ready-for-agent
+
+## Parent
+
+#1
+
+## What to build
+
+The server and the vfx service agree on one VFX Job contract: the queue name and the payload shape are each defined in exactly one place per runtime, and the publisher's name matches the subscriber's. A VFX Job published after transcription is actually received by the vfx service. A malformed or unexpected payload fails loudly — logged with enough context to debug, never silently dropped.
+
+## Acceptance criteria
+
+- [ ] Publishing a VFX Job from the server delivers it to the vfx service (visible in the queue's management UI)
+- [ ] Queue name and payload shape are each defined once per runtime and derived from that definition
+- [ ] A malformed payload produces a clear error log and is not silently dropped
+- [ ] The transcription's Transcription Segments reach the vfx service unchanged
+
+## Blocked by
+
+None — can start immediately.

--- a/.scratch/architecture-review/issues/02-deepen-vfx-render-module.md
+++ b/.scratch/architecture-review/issues/02-deepen-vfx-render-module.md
@@ -1,0 +1,26 @@
+# 02 — deepen-vfx-render-module
+
+**GitHub issue:** #3
+
+**Status:** ready-for-agent
+
+## Parent
+
+#1
+
+## What to build
+
+The vfx service's render path becomes one module that owns everything render-related: id derivation from the object key, temporary paths (with real file names and extensions), render options, the ffmpeg invocation, and the Output upload. A received VFX Job either produces an Output at `outputs/<id>` and publishes a JobCompleted event (upload id + output key), or is requeued; after repeated failures it dead-letters. The consumer can no longer wedge permanently after a few failures.
+
+## Acceptance criteria
+
+- [ ] A synthetic VFX Job results in a rendered Output object at `outputs/<id>` in object storage
+- [ ] No caller passes directory paths where file paths are required; the module derives every path it uses
+- [ ] Render options (frame rate, dimensions) come from configuration, not hardcoded call sites
+- [ ] Failed jobs are requeued; repeated failures dead-letter after a bounded number of attempts
+- [ ] A successful render publishes a JobCompleted event carrying the upload id and output key
+- [ ] Consumer prefetch is configuration rather than a machine-specific constant
+
+## Blocked by
+
+- #2 — the job contract must exist before the render module consumes it.

--- a/.scratch/architecture-review/issues/03-job-status-module-and-api.md
+++ b/.scratch/architecture-review/issues/03-job-status-module-and-api.md
@@ -1,0 +1,24 @@
+# 03 — job-status-module-and-api
+
+**GitHub issue:** #4
+
+**Status:** ready-for-agent
+
+## Parent
+
+#1
+
+## What to build
+
+A job's Process lifecycle (uploaded → transcribing → rendering → done/failed) exists as real server-side state. The server consumes the JobCompleted event and records transitions; the state is exposed through read-only endpoints `GET /jobs` and `GET /jobs/:id`, each job response including its current stage and the download URL for its Output when done. The persistence mechanism is chosen during implementation — revive the dormant database package or keep in-memory state with documented trade-offs — and the choice is recorded as an ADR so future reviews do not re-litigate it.
+
+## Acceptance criteria
+
+- [ ] An end-to-end run's status is queryable and reflects the real lifecycle stages
+- [ ] A done job's response includes a working download URL for its Output
+- [ ] Unknown job ids return a 404; malformed requests are rejected
+- [ ] The persistence choice is recorded as an ADR (or a decision note on this issue)
+
+## Blocked by
+
+- #3 — the completion event that feeds this module is published by the render module.

--- a/.scratch/architecture-review/issues/04-real-process-tracking-client.md
+++ b/.scratch/architecture-review/issues/04-real-process-tracking-client.md
@@ -1,0 +1,24 @@
+# 04 — real-process-tracking-client
+
+**GitHub issue:** #5
+
+**Status:** ready-for-agent
+
+## Parent
+
+#1
+
+## What to build
+
+The client's processes list and detail pages read real Process state from the status API instead of localStorage, poll it while a job is in flight, and download via the API-provided URL. All fabricated ids, sample data, and simulated progress are deleted — the client invents nothing the server owns.
+
+## Acceptance criteria
+
+- [ ] Uploading a video shows its real Process moving through the pipeline stages
+- [ ] The download button delivers the actual rendered video
+- [ ] No fabricated process ids, sample data, or timer-based simulated progress remain
+- [ ] The pages handle in-flight, done, and failed states from the API
+
+## Blocked by
+
+- #4 — the status API must exist for the client to read.

--- a/.scratch/architecture-review/issues/05-one-env-contract.md
+++ b/.scratch/architecture-review/issues/05-one-env-contract.md
@@ -1,0 +1,24 @@
+# 05 — one-env-contract
+
+**GitHub issue:** #6
+
+**Status:** ready-for-agent
+
+## Parent
+
+#1
+
+## What to build
+
+One documented environment contract across the three services: the variable names (`S3_*`, `RABBITMQ_*`, `PORT`, `TMP_DIR`, `CLIENT_URL`, `WHISPER_MODEL_PATH`) live in a single documented place, and each runtime keeps a thin, typed loader that fails loudly at boot when a required variable is missing. No silent credential or URL defaults remain. The S3 rename already shipped with the storage migration; this ticket finishes the contract for the remaining variables.
+
+## Acceptance criteria
+
+- [ ] The full variable contract is documented in one place (README or a dedicated env doc)
+- [ ] All three loaders fail loudly on missing required variables with a clear message naming the variable
+- [ ] No loader silently falls back to default credentials or URLs
+- [ ] All services boot using only documented variables
+
+## Blocked by
+
+None — can start immediately.

--- a/.scratch/architecture-review/issues/06-delete-ghost-pipeline.md
+++ b/.scratch/architecture-review/issues/06-delete-ghost-pipeline.md
@@ -1,0 +1,24 @@
+# 06 — delete-ghost-pipeline
+
+**GitHub issue:** #7
+
+**Status:** ready-for-agent
+
+## Parent
+
+#1
+
+## What to build
+
+The abandoned synchronous subtitle pipeline is deleted: the commented-out block in the upload processor, the server packages nothing imports, the dead parameter on the tusd registration, and the byte-identical duplicated client hooks. Only the queue-based architecture remains to read. The SRT writer is included — the queue-based path renders via Remotion, and git preserves the file if plain-SRT output ever returns.
+
+## Acceptance criteria
+
+- [ ] Unused server packages, the commented-out processor block, and the dead parameter are removed
+- [ ] Duplicated client hooks are deduplicated
+- [ ] The server builds and the client typechecks after deletion
+- [ ] Nothing that remains references the deleted code
+
+## Blocked by
+
+None — can start immediately.

--- a/.scratch/architecture-review/spec.md
+++ b/.scratch/architecture-review/spec.md
@@ -1,0 +1,72 @@
+# Spec — make the subtitle pipeline real
+
+**GitHub issue:** #1 (label: ready-for-agent)
+
+**Tickets:** #2 → #3 → #4 → #5 · #6 · #7 (blocking edges set natively on GitHub)
+
+---
+
+## Parent
+
+Architecture review, 2026-09-03 (implemented as a series of child issues). Storage migration decision: ADR-0001.
+
+## Problem Statement
+
+A creator uploads a video and expects subtitles, but everything after the upload is unreliable or fake: the job that should trigger subtitle rendering is silently never received by the rendering service, the render path itself cannot complete, the "track your process" pages simulate progress with random numbers, and the download button delivers nothing. Meanwhile the three services each invent their own configuration vocabulary, and the codebase carries a second, abandoned architecture that every reader must pay to understand.
+
+## Solution
+
+Make the pipeline real end to end. Reconnect the job handoff with a contract defined once per runtime, concentrate all render-path complexity into one deep render module, give a job's lifecycle real server-side state exposed by a small status API, let the client track that real state and download real outputs, collapse configuration into one documented contract, and delete the ghost pipeline. Tests cross exactly three seams: the job queue (write side), the status API (read side), and the storage client (in-process, faked in tests).
+
+## User Stories
+
+1. As a creator, I want my uploaded video to actually flow through subtitle generation, so that I receive real subtitles instead of a stalled process.
+2. As a creator, I want the process page to show my job's real current stage (transcribing, rendering, done), so that I know whether to wait or come back later.
+3. As a creator, I want to download the rendered video with burned-in subtitles once the job completes, so that the product delivers its core promise.
+4. As a creator, I want a failed job to surface as a clear failure state, so that I am not left watching a fake progress bar.
+5. As a maintainer, I want the VFX Job contract defined in exactly one place per runtime, so that a rename cannot silently sever the pipeline again.
+6. As a maintainer, I want malformed job payloads to fail loudly, so that contract drift is visible instead of swallowed.
+7. As a maintainer, I want failed render jobs to be requeued, so that one bad video cannot wedge the worker.
+8. As a maintainer, I want repeatedly failing jobs to dead-letter after a bounded number of attempts, so that the queue self-heals.
+9. As a maintainer, I want temporary paths, output naming, and render options owned by the render module, so that caller-side path bugs cannot recur.
+10. As a maintainer, I want a job's lifecycle kept as real server-side state, so that the client never invents state.
+11. As a maintainer, I want the persistence choice for job state recorded as a decision, so that future reviews do not re-litigate it.
+12. As the client app, I want one read-only status interface, so that tracking is a thin polling surface with a single source of truth.
+13. As a maintainer, I want the simulated tracking data removed, so that there is exactly one representation of a Process.
+14. As an operator, I want one documented environment contract, so that booting the stack is copy-paste from a single page.
+15. As a maintainer, I want configuration loaders that fail loudly at boot, so that misconfiguration never hides behind silent defaults in production.
+16. As an agent, I want the abandoned synchronous pipeline deleted, so that navigating the codebase means reading one architecture, not two.
+17. As a maintainer, I want tests only at the three confirmed seams, so that refactors stay cheap and tests never pin implementation details.
+
+## Implementation Decisions
+
+- The **job contract** — queue name and payload shape — is defined once per runtime. The payload carries the upload id, the upload's object key, and its Transcription Segments; the animation-type field is reserved but unused. Consumers validate payloads; a parse failure logs a clear error and is not silently dropped.
+- The **render module** in the vfx service owns id derivation from the object key, all temporary paths (including file extensions), render options (frame rate, dimensions), the ffmpeg invocation, and the Output upload. Callers pass a job and receive an outcome; they make no path or option decisions.
+- **Completion semantics**: a successful render publishes a JobCompleted event (upload id + output key); a failed job is requeued; after a bounded number of attempts it dead-letters. Consumer prefetch is configuration, not a machine-specific constant.
+- The **Job module** in the server owns the Process lifecycle (uploaded → transcribing → rendering → done/failed), consumes JobCompleted, and exposes read-only status over `GET /jobs` and `GET /jobs/:id`, including the download URL for the Output. The persistence mechanism is chosen during implementation and recorded as a decision (revive the dormant database package vs. in-memory state with documented trade-offs).
+- The **client** reads Process state only through the status interface and downloads only via the API-provided URL. All fabricated ids, sample data, and simulated progress are deleted.
+- The **environment contract** (`S3_*`, `RABBITMQ_*`, `PORT`, `TMP_DIR`, `CLIENT_URL`, `WHISPER_MODEL_PATH`) is documented in one place; each runtime keeps a thin, typed loader that fails loudly on missing required variables.
+- The **ghost pipeline** is deleted: unused server packages, the commented-out synchronous subtitle path, an unused handler parameter, and duplicated client hooks. The SRT writer goes with it — git preserves it if a plain-SRT output ever returns.
+- Per ADR-0001, all storage access stays behind the S3 seam; no vendor name appears in any module interface.
+
+## Testing Decisions
+
+- A good test checks external behavior only — never internals. Tests cross exactly three seams: the VFX-job queue, the status API, and the storage client.
+- The render path is verified end to end at the queue seam: a synthetic VFX Job results in an Output object at `outputs/<id>`; a malformed payload produces a visible failure, not silence.
+- Processor-level tests run against a fake storage client, so no live object store is needed for unit work.
+- The status API is tested over HTTP: lifecycle events move a job through its states; unknown ids 404.
+- Prior art: none — the repo has no tests today; these establish the pattern (the Go standard testing package on the server; the vfx service's standard runtime test runner).
+- The client is verified against the API seam plus a manual UI pass; client test infrastructure is out of scope.
+
+## Out of Scope
+
+- User subtitle preferences (language, color, outline, border, font, size, vertical margin) — a separate feature needing its own spec.
+- Splitting Transcription Segments by max characters or seconds; user-configurable video resizing.
+- Transcription performance (the whisper model is reloaded per call — flagged for a future ticket).
+- Authentication, multi-tenancy, RustFS multi-node or TLS setups, and CI pipeline setup.
+
+## Further Notes
+
+- Origin: the 2026-09-03 architecture review. The storage seam work (review candidate 1) is already delivered and recorded in ADR-0001; the remaining six candidates are ticketed as child issues with blocking edges, in dependency order.
+- The review's report file is ephemeral (`/tmp`); this issue plus the child issues are the durable record.
+- Fixing the handoff activates the render path for the first time — the render module ticket must land with or before the reconnection goes live, per the review's warning.

--- a/.scratch/editor/spec.md
+++ b/.scratch/editor/spec.md
@@ -1,0 +1,55 @@
+# Editor + styling: settled spec (grilling session 2026-09-03)
+
+Decisions from the interview, in force for this implementation. Glossary terms
+live in `CONTEXT.md` (Edit Spec, Frame, Frame Preset, Subtitle Style); the
+architecture decision is recorded in `docs/adr/0003-edit-spec-via-tus-metadata.md`.
+
+## Flow
+
+choose video (home dropzone) → `/editor` (Frame, Trim, Animation, Subtitle
+Style) → Generate → tus upload carries the Edit Spec as `editSpec` metadata →
+server validates fail-loud → VFX Job applies it at render → `/processes`
+gallery tracks the Process.
+
+## Frame (crop-to-fill)
+
+Presets: 9:16, 4:5, 1:1, 16:9, Free (drag corner, ratio 0.5–2.0 in the UI,
+0.3–3.5 in the contract). Zoom 1–5×, pan ±1 (normalized overflow). Applied by
+ffmpeg `scale→crop` server-side; the subtitle overlay renders at the target
+frame size.
+
+## Trim
+
+Dual-handle slider, looped preview inside the window. Server shifts segment
+times by the trim start and cuts the video with ffmpeg. No filmstrip this pass.
+
+## Animation
+
+`fade`, `slide`, `karaoke`, plus new **Pop** (shorts-style word-by-word
+captions: words pop in one at a time with a spring scale, active word
+highlighted; word timing = segment duration weighted by word length — segments
+carry no word timestamps). `random` is resolved client-side at submit; the
+contract always carries a concrete animation. vfx honors per-job animation,
+`RENDER_TEMPLATE` stays as the fallback for jobs without an Edit Spec.
+
+## Subtitle Style (knobs, all with live preview in the editor)
+
+fontFamily (bundled: Montserrat, Inter, Poppins, Oswald, Bebas Neue, Anton),
+fontSizeScale (0.5–2), color, outlineWidth (0–32 px @1080 reference) +
+outlineColor, bottomMargin (0–0.8 fraction of frame height), background
+(none|box) + backgroundOpacity, uppercase, highlightColor (karaoke/pop).
+Preview uses sample text — transcription happens after upload.
+
+## Contract
+
+`editSpec` is optional in the VFX Job payload (jobs without one render as
+before); when present, every field is required and validated in both mirrors
+(`server/internal/editspec` and `vfx/src/contract.ts`). The old reserved
+top-level `animationType` is removed.
+
+## UI
+
+shadcn on Tailwind v4, dark-first studio theme (near-black neutrals, one
+chartreuse accent, Space Grotesk display + Inter body). Gallery = grid of
+hover-preview videos from the existing download URL, no server changes.
+WebGPU: intentionally skipped.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues is the tracker of record (via `gh` CLI), with a local-markdown scratch layer under `.scratch/<feature>/` for drafts and work in flight. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage labels, used as-is: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout: one `CONTEXT.md` plus `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,10 @@ the Next.js client uploads videos with tus.
   and carried inside the Edit Spec.
 - **Output** — the rendered video with burned-in subtitles, stored under
   `outputs/<id>` with the same `<id>` as the Upload.
+- **Delete** — the one-way removal of a Process: its record and both stored
+  objects (the Upload and, if rendered, the Output) are erased. Irreversible —
+  no archive, no restore. A Delete never cancels work already in flight; that
+  is Cancel, a separate concept not yet built (see ADR-0004).
 - **Process** — the client-facing lifecycle of a job (uploaded →
   transcribing → rendering → done/failed). Real server-side state, owned by
   the server's job module, exposed read-only by the status API

--- a/client/components/process-details.tsx
+++ b/client/components/process-details.tsx
@@ -9,13 +9,16 @@ import {
   Download,
   FileVideo2,
   Loader2,
+  Trash2,
   XCircle,
 } from 'lucide-react';
 
 import { STAGE_LABEL } from '@/components/process-stage';
+import { DeleteProcessDialog } from '@/components/process-gallery';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { useRouter } from 'next/navigation';
 import { useProcess } from '@/hooks/use-process-polling';
 import { IN_FLIGHT_STAGES, downloadUrl, type ProcessStage } from '@/lib/api';
 
@@ -31,6 +34,8 @@ const PIPELINE_STAGES: ProcessStage[] = [
 
 export function ProcessDetails({ processId }: { processId: string }) {
   const { process, notFound, error } = useProcess(processId);
+  const router = useRouter();
+  const [deleteOpen, setDeleteOpen] = React.useState(false);
 
   const handleDownload = () => {
     if (!process?.downloadUrl) return;
@@ -89,13 +94,21 @@ export function ProcessDetails({ processId }: { processId: string }) {
               · Process {process.id}
             </p>
           </div>
-          <div className="ml-auto">
+          <div className="ml-auto flex items-center gap-2">
             {done && (
               <Button onClick={handleDownload}>
                 <Download className="h-4 w-4" />
                 Download
               </Button>
             )}
+            <Button
+              variant="outline"
+              className="border-red-500/30 text-red-400 hover:bg-red-500/10 hover:text-red-400"
+              onClick={() => setDeleteOpen(true)}
+            >
+              <Trash2 className="h-4 w-4" />
+              Delete
+            </Button>
           </div>
         </div>
 
@@ -182,6 +195,15 @@ export function ProcessDetails({ processId }: { processId: string }) {
           </p>
         </Card>
       ) : null}
+
+      {process && (
+        <DeleteProcessDialog
+          process={process}
+          open={deleteOpen}
+          onOpenChange={setDeleteOpen}
+          onDeleted={() => router.push('/processes')}
+        />
+      )}
     </div>
   );
 }

--- a/client/components/process-gallery.tsx
+++ b/client/components/process-gallery.tsx
@@ -1,68 +1,183 @@
 'use client';
 
+import * as React from 'react';
 import Link from 'next/link';
 import { formatDistanceToNow } from 'date-fns';
-import { Clapperboard, FileVideo2, Loader2 } from 'lucide-react';
+import { FileVideo2, Loader2, Trash2 } from 'lucide-react';
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { StageBadge } from '@/components/process-stage';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { useProcessList } from '@/hooks/use-process-polling';
+import { useProcessDelete, useProcessList } from '@/hooks/use-process-polling';
 import { downloadUrl, type Process } from '@/lib/api';
 
 // The gallery: every Process as a card. Finished videos preview on hover
 // straight from the server's download endpoint — no thumbnails, no server
-// changes; in-flight jobs show their live stage instead.
+// changes; in-flight jobs show their live stage instead. Delete lives on the
+// card too (ADR-0004): an immediate, irreversible erase of the record and
+// both stored objects.
+
+export function DeleteProcessDialog({
+  process,
+  open,
+  onOpenChange,
+  onDeleted,
+  trigger,
+}: {
+  process: Pick<Process, 'id' | 'filename'>;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onDeleted?: () => void;
+  trigger?: React.ReactNode;
+}) {
+  const { removeProcess, deleting } = useProcessDelete();
+  const [error, setError] = React.useState<string | null>(null);
+
+  const handleDelete = async () => {
+    setError(null);
+    try {
+      await removeProcess(process.id);
+      onOpenChange(false);
+      onDeleted?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete the process');
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      {trigger}
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this process?</AlertDialogTitle>
+          <AlertDialogDescription>
+            “{process.filename || process.id}” and its rendered result will be permanently
+            removed from the gallery and storage. This cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={deleting}
+            onClick={(event) => {
+              event.preventDefault();
+              void handleDelete();
+            }}
+            className="bg-red-600 text-white hover:bg-red-600/90"
+          >
+            {deleting && <Loader2 className="h-4 w-4 animate-spin" />}
+            Delete forever
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export function DeleteProcessButton({
+  process,
+  onDeleted,
+  className,
+  label = 'Delete',
+}: {
+  process: Pick<Process, 'id' | 'filename'>;
+  onDeleted?: () => void;
+  className?: string;
+  label?: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <DeleteProcessDialog
+      process={process}
+      open={open}
+      onOpenChange={setOpen}
+      onDeleted={onDeleted}
+      trigger={
+        <button
+          type="button"
+          aria-label={label}
+          className={className}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            setOpen(true);
+          }}
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      }
+    />
+  );
+}
 
 function GalleryCard({ process }: { process: Process }) {
   const done = process.stage === 'done' && Boolean(process.downloadUrl);
   const src = done ? downloadUrl(process) : null;
 
   return (
-    <Link href={`/processes/${process.id}`} className="group block">
-      <Card className="overflow-hidden border-border/70 bg-card/50 p-0 transition-colors group-hover:border-primary/40">
-        <div className="relative aspect-video bg-black/50">
-          {src ? (
-            <video
-              src={`${src}#t=0.5`}
-              muted
-              loop
-              playsInline
-              preload="metadata"
-              className="h-full w-full object-contain"
-              onMouseEnter={(event) => {
-                void event.currentTarget.play().catch(() => {});
-              }}
-              onMouseLeave={(event) => {
-                event.currentTarget.pause();
-                event.currentTarget.currentTime = 0.5;
-              }}
-            />
-          ) : (
-            <div className="flex h-full w-full flex-col items-center justify-center gap-3">
-              <FileVideo2 className="h-10 w-10 text-muted-foreground/50" />
-              {process.stage === 'failed' ? (
-                <p className="max-w-[85%] truncate text-xs text-red-400">
-                  {process.reason || 'Render failed'}
-                </p>
-              ) : (
-                <p className="text-xs text-muted-foreground">Rendering your video…</p>
-              )}
+    <div className="group relative">
+      <Link href={`/processes/${process.id}`} className="block">
+        <Card className="overflow-hidden border-border/70 bg-card/50 p-0 transition-colors group-hover:border-primary/40">
+          <div className="relative aspect-video bg-black/50">
+            {src ? (
+              <video
+                src={`${src}#t=0.5`}
+                muted
+                loop
+                playsInline
+                preload="metadata"
+                className="h-full w-full object-contain"
+                onMouseEnter={(event) => {
+                  void event.currentTarget.play().catch(() => {});
+                }}
+                onMouseLeave={(event) => {
+                  event.currentTarget.pause();
+                  event.currentTarget.currentTime = 0.5;
+                }}
+              />
+            ) : (
+              <div className="flex h-full w-full flex-col items-center justify-center gap-3">
+                <FileVideo2 className="h-10 w-10 text-muted-foreground/50" />
+                {process.stage === 'failed' ? (
+                  <p className="max-w-[85%] truncate text-xs text-red-400">
+                    {process.reason || 'Render failed'}
+                  </p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">Rendering your video…</p>
+                )}
+              </div>
+            )}
+            {/* A dark plate keeps the badge readable over bright video frames */}
+            <div className="absolute right-2 top-2 rounded-full bg-black/55 p-0.5 backdrop-blur-sm">
+              <StageBadge stage={process.stage} />
             </div>
-          )}
-          {/* A dark plate keeps the badge readable over bright video frames */}
-          <div className="absolute right-2 top-2 rounded-full bg-black/55 p-0.5 backdrop-blur-sm">
-            <StageBadge stage={process.stage} />
           </div>
-        </div>
-        <div className="p-3">
-          <p className="truncate text-sm font-medium">{process.filename || process.id}</p>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            {formatDistanceToNow(new Date(process.createdAt), { addSuffix: true })}
-          </p>
-        </div>
-      </Card>
-    </Link>
+          <div className="p-3 pr-10">
+            <p className="truncate text-sm font-medium">{process.filename || process.id}</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {formatDistanceToNow(new Date(process.createdAt), { addSuffix: true })}
+            </p>
+          </div>
+        </Card>
+      </Link>
+      <DeleteProcessButton
+        process={process}
+        className="absolute bottom-3 right-3 inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground/70 opacity-0 transition-opacity hover:bg-red-500/10 hover:text-red-400 focus-visible:opacity-100 group-hover:opacity-100"
+        label={`Delete ${process.filename || process.id}`}
+      />
+    </div>
   );
 }
 
@@ -71,7 +186,7 @@ export function ProcessGallery() {
 
   if (processes === null && !error) {
     return (
-      <div className="flex justify-center items-center py-24">
+      <div className="flex items-center justify-center py-24">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     );
@@ -90,7 +205,7 @@ export function ProcessGallery() {
   if (processes !== null && processes.length === 0) {
     return (
       <Card className="flex flex-col items-center justify-center border-border/70 bg-card/50 py-16">
-        <Clapperboard className="mb-4 h-10 w-10 text-muted-foreground/60" />
+        <FileVideo2 className="mb-4 h-10 w-10 text-muted-foreground/60" />
         <h3 className="font-display text-lg font-semibold">Nothing here yet</h3>
         <p className="mt-2 text-center text-sm text-muted-foreground">
           Caption your first video and it will show up here.

--- a/client/hooks/use-process-polling.ts
+++ b/client/hooks/use-process-polling.ts
@@ -1,13 +1,28 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import { IN_FLIGHT_STAGES, ProcessNotFoundError, fetchJob, fetchJobs, type Process } from '@/lib/api';
+import {
+  IN_FLIGHT_STAGES,
+  ProcessNotFoundError,
+  deleteProcess,
+  fetchJob,
+  fetchJobs,
+  type Process,
+} from '@/lib/api';
 
 // Polling against the status API: the client never invents state, it re-reads
-// the server's while a job is in flight and stops once it reaches a terminal
-// one. Both hooks schedule the next poll with a timeout chain, so there is
-// exactly one request in the air at a time.
+// the server's while a process is in flight and stops once it reaches a
+// terminal one. Both hooks schedule the next poll with a timeout chain, so
+// there is exactly one request in the air at a time. removeProcess deletes a
+// process server-side and every other hook instance picks the change up on
+// its next poll — a gentle broadcast through a window event.
+
+const PROCESSES_CHANGED = 'subvision:processes-changed';
+
+function notifyProcessesChanged() {
+  window.dispatchEvent(new Event(PROCESSES_CHANGED));
+}
 
 export function useProcessList() {
   const [processes, setProcesses] = useState<Process[] | null>(null);
@@ -33,10 +48,17 @@ export function useProcessList() {
       }
     };
 
+    const refresh = () => {
+      if (timer) clearTimeout(timer);
+      void poll();
+    };
+
     poll();
+    window.addEventListener(PROCESSES_CHANGED, refresh);
     return () => {
       cancelled = true;
       if (timer) clearTimeout(timer);
+      window.removeEventListener(PROCESSES_CHANGED, refresh);
     };
   }, []);
 
@@ -67,6 +89,11 @@ export function useProcess(id: string) {
         if (err instanceof ProcessNotFoundError) {
           // A 404 right after the upload may mean the server hasn't
           // recorded the process yet; retry briefly before giving up.
+          // A 404 after this process was deleted is final — stop polling.
+          if (deletedIds.has(id)) {
+            setNotFound(true);
+            return;
+          }
           unknownAttempts += 1;
           if (unknownAttempts >= 15) {
             setNotFound(true);
@@ -80,12 +107,43 @@ export function useProcess(id: string) {
       }
     };
 
+    const refresh = () => {
+      if (timer) clearTimeout(timer);
+      void poll();
+    };
+
     poll();
+    window.addEventListener(PROCESSES_CHANGED, refresh);
     return () => {
       cancelled = true;
       if (timer) clearTimeout(timer);
+      window.removeEventListener(PROCESSES_CHANGED, refresh);
     };
   }, [id]);
 
   return { process, notFound, error };
+}
+
+// Ids deleted in this tab; the details hook uses it to stop its
+// not-found retry grace period for its own deletes.
+const deletedIds = new Set<string>();
+
+export function useProcessDelete() {
+  const [deleting, setDeleting] = useState(false);
+
+  const removeProcess = useCallback(async (id: string) => {
+    setDeleting(true);
+    try {
+      deletedIds.add(id);
+      await deleteProcess(id);
+      notifyProcessesChanged();
+    } catch (err) {
+      deletedIds.delete(id);
+      throw err;
+    } finally {
+      setDeleting(false);
+    }
+  }, []);
+
+  return { removeProcess, deleting };
 }

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -1,7 +1,8 @@
 import { env } from '@/configs/env';
 
-// The client reads Process state only through the server's status API and
-// downloads only via the API-provided URL — it invents nothing the server owns.
+// The client reads Process state only through the server's status API,
+// deletes through the same API, and downloads only via the API-provided URL
+// — it invents nothing the server owns.
 
 export type ProcessStage = 'uploaded' | 'transcribing' | 'rendering' | 'done' | 'failed';
 
@@ -29,6 +30,7 @@ export class ProcessNotFoundError extends Error {
 }
 
 type JSendSuccess<T> = { status: 'success'; data: T };
+type JSendFail = { status: 'fail'; data: Record<string, unknown> };
 
 async function request<T>(path: string): Promise<T> {
   const res = await fetch(`${env.serverUrl}${path}`);
@@ -68,6 +70,25 @@ export async function fetchJob(id: string): Promise<Process> {
     }
     throw error;
   }
+}
+
+// Delete is irreversible: the Process record and both stored objects (the
+// upload and, if rendered, the output) are erased server-side (ADR-0004).
+export async function deleteProcess(id: string): Promise<void> {
+  const res = await fetch(`${env.serverUrl}/jobs/${encodeURIComponent(normalizeJobId(id))}`, {
+    method: 'DELETE',
+  });
+  if (res.status === 404) {
+    throw new ProcessNotFoundError(id);
+  }
+  if (res.status === 204) {
+    return;
+  }
+  if (!res.ok) {
+    throw new Error(`delete returned ${res.status}`);
+  }
+  const body = (await res.json()) as JSendFail;
+  throw new Error(String(body.data?.id ?? 'delete failed'));
 }
 
 // The URL the API provides for the rendered Output; the server streams it as

--- a/docs/adr/0004-immediate-best-effort-delete.md
+++ b/docs/adr/0004-immediate-best-effort-delete.md
@@ -1,0 +1,39 @@
+# ADR-0004: Process deletion is immediate and best-effort; it does not cancel work
+
+Date: 2026-09-03 · Status: accepted
+
+## Context
+
+The gallery is read-only today; users cannot remove old videos. Deleting a
+Process means erasing three things: the SQLite row, the Upload object, and
+the Output object. But the pipeline is asynchronous — an upload job may be
+sitting in RabbitMQ, whisper may be transcribing, or the vfx service may be
+rendering while the user presses delete. Coordinating a true cancellation
+across all of that is a contract change (ADR-grade) and is deferred.
+
+## Decision
+
+- `DELETE /jobs/:id` hard-deletes the Process row first (source of truth for
+  the UI), then removes `uploads/<id>` and `outputs/<id>` best-effort.
+- Deletion is allowed at any stage, including in-flight. A racing worker's
+  eventual write is discarded: the store rejects transitions for unknown or
+  terminal jobs, so the row cannot resurrect.
+- No soft delete, no archive. Deletion is irreversible by design.
+- Real cancellation (stopping whisper/ffmpeg/render, aborting tus uploads)
+  stays a separate feature with its own design.
+
+## Alternatives considered
+
+- **Refuse to delete in-flight jobs (409)** — simplest, but the delete button
+  would be dead exactly when users want it (a stuck or unwanted render).
+  Rejected.
+- **Soft delete (`deleted_at` column)** — buys restore/undo nobody asked for;
+  every list and query now filters forever. Rejected.
+
+## Consequences
+
+- A worker that finishes just after object deletion can orphan a fresh
+  `outputs/<id>` (the row is already gone, so nothing points at it). Storage
+  junk, never a UI ghost; clean manually if it appears.
+- Failure to remove an object is logged loudly, not retried — the UI outcome
+  (row deleted, list refreshed) is not held hostage to storage errors.

--- a/server/cmd/subvision/main.go
+++ b/server/cmd/subvision/main.go
@@ -11,8 +11,8 @@ import (
 	"github.com/rubichandrap/subvision/server/internal/handler"
 	"github.com/rubichandrap/subvision/server/internal/job"
 	"github.com/rubichandrap/subvision/server/internal/processor"
-	"github.com/rubichandrap/subvision/server/internal/storage"
 	"github.com/rubichandrap/subvision/server/internal/rabbitmq"
+	"github.com/rubichandrap/subvision/server/internal/storage"
 	"github.com/rubichandrap/subvision/server/internal/transcriber"
 	"github.com/rubichandrap/subvision/server/internal/utils"
 	"github.com/rubichandrap/subvision/server/internal/vfxjob"
@@ -186,8 +186,8 @@ func main() {
 	// Register tusd handler
 	handler.RegisterTusd(r, tusdHandler)
 
-	// Register the read-only status API over the Process lifecycle
-	handler.RegisterJobs(r, jobs, objectStore)
+	// Register the status API over the Process lifecycle plus Process deletion
+	handler.RegisterJobs(r, jobs, jobs, objectStore, objectStore)
 
 	log.Println("Starting Subvision backend on port", env.Port)
 	if err := r.Run(":" + env.Port); err != nil {

--- a/server/internal/config/storage.go
+++ b/server/internal/config/storage.go
@@ -1,3 +1,8 @@
 package config
 
-const ObjectPrefix = "uploads/"
+const (
+	// ObjectPrefix holds the raw uploads tusd stores; the id is the tus id.
+	ObjectPrefix = "uploads/"
+	// OutputPrefix holds the rendered Outputs; the id matches the upload's.
+	OutputPrefix = "outputs/"
+)

--- a/server/internal/handler/jobs.go
+++ b/server/internal/handler/jobs.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rubichandrap/subvision/server/internal/config"
 	"github.com/rubichandrap/subvision/server/internal/job"
 	"github.com/rubichandrap/subvision/server/internal/primitives"
 )
@@ -22,9 +23,21 @@ type JobReader interface {
 	Get(id string) (*job.Process, error)
 }
 
+// JobDeleter removes a Process record entirely; implemented by the job store.
+type JobDeleter interface {
+	Delete(id string) (bool, error)
+}
+
 // OutputOpener streams an Output object from storage.
 type OutputOpener interface {
 	Open(ctx context.Context, key string) (io.ReadCloser, int64, error)
+}
+
+// ObjectCleaner deletes every stored object under a key prefix (the Upload
+// and the Output ride under `uploads/` and `outputs/`); implemented by the
+// storage client.
+type ObjectCleaner interface {
+	Delete(ctx context.Context, prefix string) error
 }
 
 type processResponse struct {
@@ -54,8 +67,9 @@ func newProcessResponse(p *job.Process) processResponse {
 	return resp
 }
 
-// RegisterJobs exposes the read-only status API over the Process lifecycle.
-func RegisterJobs(r *gin.Engine, jobs JobReader, outputs OutputOpener) {
+// RegisterJobs exposes the status API over the Process lifecycle: reads for
+// the gallery, plus the one write — an immediate, best-effort Delete.
+func RegisterJobs(r *gin.Engine, jobs JobReader, deleter JobDeleter, outputs OutputOpener, cleaner ObjectCleaner) {
 	r.GET("/jobs", func(c *gin.Context) {
 		processes, err := jobs.List()
 		if err != nil {
@@ -110,6 +124,31 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, outputs OutputOpener) {
 		if _, err := io.Copy(c.Writer, body); err != nil {
 			log.Printf("[Jobs] Failed to stream output for job %s: %v", id, err)
 		}
+	})
+
+	// Deletion is immediate and best-effort (ADR-0004): the row goes first so
+	// the process can never reappear, then the Upload and Output objects go
+	// best-effort — an object that fails to vanish is logged, not retried; the
+	// UI outcome never hangs on storage errors.
+	r.DELETE("/jobs/:id", func(c *gin.Context) {
+		id := c.Param("id")
+		deleted, err := deleter.Delete(id)
+		if err != nil {
+			log.Printf("[Jobs] Failed to delete job %s: %v", id, err)
+			primitives.JSendError(c, "failed to delete job", http.StatusInternalServerError, nil)
+			return
+		}
+		if !deleted {
+			primitives.JSendFail(c, gin.H{"id": fmt.Sprintf("no job with id %q", id)}, http.StatusNotFound)
+			return
+		}
+
+		for _, prefix := range []string{config.ObjectPrefix + id, config.OutputPrefix + id} {
+			if err := cleaner.Delete(c.Request.Context(), prefix); err != nil {
+				log.Printf("[Jobs] Failed to clean objects under %s for deleted job %s: %v", prefix, id, err)
+			}
+		}
+		c.Status(http.StatusNoContent)
 	})
 }
 

--- a/server/internal/handler/jobs_test.go
+++ b/server/internal/handler/jobs_test.go
@@ -27,7 +27,16 @@ func (f *fakeOutputs) Open(ctx context.Context, key string) (io.ReadCloser, int6
 	return io.NopCloser(strings.NewReader(f.body)), int64(len(f.body)), nil
 }
 
-func newJobsRouter(t *testing.T) (*gin.Engine, *job.Store, *fakeOutputs) {
+type fakeCleaner struct {
+	deleted []string
+}
+
+func (f *fakeCleaner) Delete(ctx context.Context, prefix string) error {
+	f.deleted = append(f.deleted, prefix)
+	return nil
+}
+
+func newJobsRouter(t *testing.T) (*gin.Engine, *job.Store, *fakeOutputs, *fakeCleaner) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -42,9 +51,10 @@ func newJobsRouter(t *testing.T) (*gin.Engine, *job.Store, *fakeOutputs) {
 		t.Fatalf("create job store: %v", err)
 	}
 	outputs := &fakeOutputs{body: "video bytes"}
+	cleaner := &fakeCleaner{}
 	router := gin.New()
-	RegisterJobs(router, store, outputs)
-	return router, store, outputs
+	RegisterJobs(router, store, store, outputs, cleaner)
+	return router, store, outputs, cleaner
 }
 
 func doGet(t *testing.T, router *gin.Engine, path string) *httptest.ResponseRecorder {
@@ -55,8 +65,16 @@ func doGet(t *testing.T, router *gin.Engine, path string) *httptest.ResponseReco
 	return rec
 }
 
+func doDelete(t *testing.T, router *gin.Engine, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete, path, nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
 func TestLifecycleMovesThroughTheStatusAPI(t *testing.T) {
-	router, store, _ := newJobsRouter(t)
+	router, store, _, _ := newJobsRouter(t)
 
 	if err := store.Create("u1", "clip.mp4"); err != nil {
 		t.Fatalf("create: %v", err)
@@ -113,7 +131,7 @@ func TestLifecycleMovesThroughTheStatusAPI(t *testing.T) {
 }
 
 func TestFailedJobSurfacesItsReason(t *testing.T) {
-	router, store, _ := newJobsRouter(t)
+	router, store, _, _ := newJobsRouter(t)
 
 	if err := store.Create("u2", "broken.mov"); err != nil {
 		t.Fatalf("create: %v", err)
@@ -136,7 +154,7 @@ func TestFailedJobSurfacesItsReason(t *testing.T) {
 }
 
 func TestUnknownJobIDReturns404(t *testing.T) {
-	router, _, _ := newJobsRouter(t)
+	router, _, _, _ := newJobsRouter(t)
 
 	for _, path := range []string{"/jobs/missing", "/jobs/missing/download"} {
 		rec := doGet(t, router, path)
@@ -150,7 +168,7 @@ func TestUnknownJobIDReturns404(t *testing.T) {
 }
 
 func TestDownloadBeforeDoneReturns404(t *testing.T) {
-	router, store, outputs := newJobsRouter(t)
+	router, store, outputs, _ := newJobsRouter(t)
 
 	if err := store.Create("u3", "clip.mp4"); err != nil {
 		t.Fatalf("create: %v", err)
@@ -166,7 +184,7 @@ func TestDownloadBeforeDoneReturns404(t *testing.T) {
 }
 
 func TestListReturnsEveryProcess(t *testing.T) {
-	router, store, _ := newJobsRouter(t)
+	router, store, _, _ := newJobsRouter(t)
 
 	if err := store.Create("u1", "one.mp4"); err != nil {
 		t.Fatalf("create u1: %v", err)
@@ -185,5 +203,81 @@ func TestListReturnsEveryProcess(t *testing.T) {
 	}
 	if !strings.Contains(body, `"status":"success"`) {
 		t.Errorf("GET /jobs body = %s, want a jsend success", body)
+	}
+}
+
+func TestDeleteRemovesRowAndCleansObjects(t *testing.T) {
+	router, store, _, cleaner := newJobsRouter(t)
+
+	if err := store.Create("u1", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if recorded, err := store.MarkDone("u1", "outputs/u1"); err != nil || !recorded {
+		t.Fatalf("mark done: recorded=%v err=%v", recorded, err)
+	}
+
+	rec := doDelete(t, router, "/jobs/u1")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE /jobs/u1 = %d: %s", rec.Code, rec.Body)
+	}
+
+	if get := doGet(t, router, "/jobs/u1"); get.Code != http.StatusNotFound {
+		t.Errorf("GET after delete = %d, want 404", get.Code)
+	}
+	if list := doGet(t, router, "/jobs"); strings.Contains(list.Body.String(), `"id":"u1"`) {
+		t.Errorf("deleted job must vanish from the list: %s", list.Body)
+	}
+
+	// both the Upload and the Output objects must be queued for cleanup
+	want := map[string]bool{"uploads/u1": false, "outputs/u1": false}
+	for _, prefix := range cleaner.deleted {
+		if _, ok := want[prefix]; ok {
+			want[prefix] = true
+		}
+	}
+	for prefix, cleaned := range want {
+		if !cleaned {
+			t.Errorf("objects under %s were not cleaned after delete (cleaned %v)", prefix, cleaner.deleted)
+		}
+	}
+}
+
+func TestDeleteInFlightJobIsAllowed(t *testing.T) {
+	router, store, _, cleaner := newJobsRouter(t)
+
+	if err := store.Create("u4", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if recorded, err := store.MarkTranscribing("u4"); err != nil || !recorded {
+		t.Fatalf("mark transcribing: recorded=%v err=%v", recorded, err)
+	}
+
+	rec := doDelete(t, router, "/jobs/u4")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE in-flight /jobs/u4 = %d: %s", rec.Code, rec.Body)
+	}
+	if get := doGet(t, router, "/jobs/u4"); get.Code != http.StatusNotFound {
+		t.Errorf("GET after delete = %d, want 404", get.Code)
+	}
+	found := false
+	for _, prefix := range cleaner.deleted {
+		if prefix == "uploads/u4" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("upload objects were not cleaned after delete (cleaned %v)", cleaner.deleted)
+	}
+}
+
+func TestDeleteUnknownJobReturns404(t *testing.T) {
+	router, _, _, cleaner := newJobsRouter(t)
+
+	rec := doDelete(t, router, "/jobs/missing")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("DELETE /jobs/missing = %d, want 404", rec.Code)
+	}
+	if len(cleaner.deleted) != 0 {
+		t.Errorf("unknown job must not touch object storage, cleaned %v", cleaner.deleted)
 	}
 }

--- a/server/internal/job/job.go
+++ b/server/internal/job/job.go
@@ -134,6 +134,20 @@ func (s *Store) MarkFailed(uploadID, reason string) (bool, error) {
 	return s.mark(uploadID, StageFailed, reason, "")
 }
 
+// Delete removes the process row entirely. It reports whether a row was
+// deleted; deleting an unknown id is not an error.
+func (s *Store) Delete(id string) (bool, error) {
+	res, err := s.db.Exec(`DELETE FROM jobs WHERE id = ?`, id)
+	if err != nil {
+		return false, fmt.Errorf("failed to delete job %s: %w", id, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("failed to delete job %s: %w", id, err)
+	}
+	return affected > 0, nil
+}
+
 // Get returns the process with the requested id, or ErrNotFound.
 func (s *Store) Get(id string) (*Process, error) {
 	row := s.db.QueryRow(

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
-// Client retrieves objects from the configured S3 bucket. Uploads arrive via
-// tusd's s3store; the server only reads them back.
+// Client reads and deletes objects in the configured S3 bucket. Uploads
+// arrive via tusd's s3store; the server reads them back and cleans them up
+// when a Process is deleted.
 type Client struct {
 	s3     *s3.Client
 	bucket string
@@ -53,5 +55,36 @@ func (c *Client) Download(ctx context.Context, key, destPath string) error {
 		return fmt.Errorf("failed to copy object to file: %w", err)
 	}
 
+	return nil
+}
+
+// Delete removes every object stored under the key prefix: the video itself
+// and, for an Upload, the tusd s3store's `<id>.info` sibling that rides under
+// the same prefix. S3 deletes are idempotent, so an already-gone object is
+// not an error.
+func (c *Client) Delete(ctx context.Context, prefix string) error {
+	paginator := s3.NewListObjectsV2Paginator(c.s3, &s3.ListObjectsV2Input{
+		Bucket: aws.String(c.bucket),
+		Prefix: aws.String(prefix),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list objects under %s: %w", prefix, err)
+		}
+		if len(page.Contents) == 0 {
+			continue
+		}
+		objects := make([]types.ObjectIdentifier, 0, len(page.Contents))
+		for _, obj := range page.Contents {
+			objects = append(objects, types.ObjectIdentifier{Key: obj.Key})
+		}
+		if _, err := c.s3.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: aws.String(c.bucket),
+			Delete: &types.Delete{Objects: objects},
+		}); err != nil {
+			return fmt.Errorf("failed to delete objects under %s: %w", prefix, err)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
## What

- `DELETE /jobs/:id` — hard-deletes the Process row, then best-effort cleans `uploads/<id>` + `outputs/<id>` (including the tusd s3store `.info` sibling). Allowed at any stage, including in-flight; unknown id returns 404 (ADR-0004).
- `job.Store.Delete` + `storage.Delete` (list + batch delete under a prefix), new `config.OutputPrefix`.
- Client: delete button with AlertDialog confirm on gallery cards (hover/focus) and the details page; delete redirects to the gallery; `useProcessDelete` + `processes-changed` window event re-syncs every polling hook, and a deleted process's detail page stops polling and shows not-found.
- Docs: **Delete** term in `CONTEXT.md`, ADR-0004 (immediate, best-effort; cancel stays a separate feature).

## Verify

- `go test ./internal/handler/ -count=1` ok (3 new delete tests), `go vet ./internal/... ./cmd/...` clean
- client `tsc --noEmit` clean, `next build` ok
- known pre-existing: `go build ./cmd/subvision` fails to link without local whisper.cpp libs — unrelated