### PR TITLE
Read segments endpoint (#33)

### DIFF
--- a/server/internal/handler/jobs.go
+++ b/server/internal/handler/jobs.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -21,6 +22,7 @@ import (
 type JobReader interface {
 	List() ([]job.Process, error)
 	Get(id string) (*job.Process, error)
+	Segments(id string) (string, error)
 }
 
 // JobDeleter removes a Process record entirely; implemented by the job store.
@@ -92,6 +94,28 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, deleter JobDeleter, outputs Out
 			return
 		}
 		primitives.JSendSuccess(c, newProcessResponse(process))
+	})
+
+	// Read segments serves the stored transcript for one process, so any
+	// client can fetch it without touching the queue or the renderer. A
+	// process with nothing stored yet reads as an empty list.
+	r.GET("/jobs/:id/segments", func(c *gin.Context) {
+		id := c.Param("id")
+		if _, err := jobs.Get(id); err != nil {
+			respondWithError(c, id, err)
+			return
+		}
+		stored, err := jobs.Segments(id)
+		if err != nil {
+			log.Printf("[Jobs] Failed to read segments for job %s: %v", id, err)
+			primitives.JSendError(c, "failed to read segments", http.StatusInternalServerError, nil)
+			return
+		}
+		segments := json.RawMessage(stored)
+		if len(stored) == 0 {
+			segments = json.RawMessage("[]")
+		}
+		primitives.JSendSuccess(c, gin.H{"segments": segments})
 	})
 
 	r.GET("/jobs/:id/download", func(c *gin.Context) {

--- a/server/internal/handler/jobs_test.go
+++ b/server/internal/handler/jobs_test.go
@@ -153,10 +153,57 @@ func TestFailedJobSurfacesItsReason(t *testing.T) {
 	}
 }
 
+func TestSegmentsEndpointServesStoredTranscript(t *testing.T) {
+	router, store, _, _ := newJobsRouter(t)
+
+	if err := store.Create("u1", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Nothing stored yet: empty list, not an error.
+	rec := doGet(t, router, "/jobs/u1/segments")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /jobs/u1/segments = %d: %s", rec.Code, rec.Body)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, `"segments":[]`) {
+		t.Errorf("unstored segments must read as an empty list: %s", body)
+	}
+
+	const stored = `[{"start":1.5,"end":2.5,"text":"hello","words":[{"text":"hello","start":1.6,"end":2.4}]}]`
+	if err := store.SaveSegments("u1", stored); err != nil {
+		t.Fatalf("save segments: %v", err)
+	}
+	if recorded, err := store.MarkRendering("u1"); err != nil || !recorded {
+		t.Fatalf("mark rendering: recorded=%v err=%v", recorded, err)
+	}
+
+	rec = doGet(t, router, "/jobs/u1/segments")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /jobs/u1/segments = %d: %s", rec.Code, rec.Body)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"status":"success"`) {
+		t.Errorf("segments body = %s, want a jsend success", body)
+	}
+	for _, want := range []string{`"start":1.5`, `"text":"hello"`, `"words":[{"text":"hello","start":1.6,"end":2.4}]`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("segments body must carry the render job shape (%s): %s", want, body)
+		}
+	}
+
+	// Segments outlive the queue message: still readable after done.
+	if recorded, err := store.MarkDone("u1", "outputs/u1"); err != nil || !recorded {
+		t.Fatalf("mark done: recorded=%v err=%v", recorded, err)
+	}
+	if rec := doGet(t, router, "/jobs/u1/segments"); !strings.Contains(rec.Body.String(), `"text":"hello"`) {
+		t.Errorf("segments must survive done: %s", rec.Body)
+	}
+}
+
 func TestUnknownJobIDReturns404(t *testing.T) {
 	router, _, _, _ := newJobsRouter(t)
 
-	for _, path := range []string{"/jobs/missing", "/jobs/missing/download"} {
+	for _, path := range []string{"/jobs/missing", "/jobs/missing/download", "/jobs/missing/segments"} {
 		rec := doGet(t, router, path)
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("GET %s = %d, want 404", path, rec.Code)


### PR DESCRIPTION
Serves stored transcript via GET /jobs/:id/segments. Unknown id 404 via existing detail path. Empty store reads as empty list. Segment shape passthrough of render job JSON (segments with timed words).