### PR TITLE
feat(client): declutter landing and footer, ease process header crowding

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -47,9 +47,6 @@ export default function Home() {
       <section className="mx-auto w-full max-w-6xl px-4 pb-24 pt-10 sm:px-6 md:pt-16">
         {/* Hero */}
         <div className="mx-auto max-w-3xl text-center">
-          <p className="mb-4 inline-flex items-center gap-1.5 border-2 border-border bg-secondary px-2.5 py-1 font-mono text-[11px] font-bold uppercase tracking-widest text-secondary-foreground shadow-brutal-sm">
-            Reframe · Caption · Export
-          </p>
           <h1 className="font-display text-4xl font-extrabold leading-[1.05] tracking-tight sm:text-5xl md:text-6xl text-balance">
             Captions that look{' '}
             <span className="relative inline-block border-2 border-border bg-primary px-3 py-0.5 text-primary-foreground shadow-brutal">

--- a/client/components/app-shell.tsx
+++ b/client/components/app-shell.tsx
@@ -80,15 +80,15 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <main className="flex-1">{children}</main>
       <footer className="border-t-2 border-border bg-muted/40">
         <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-3 px-4 py-6 text-center sm:flex-row sm:text-left sm:px-6">
-          <p className="text-xs text-muted-foreground">
-            Subvision. Video reframing and animated subtitles.
+          <p className="font-mono text-xs font-bold uppercase tracking-wide text-muted-foreground">
+            Subvision
           </p>
           <Link
             href="https://github.com/rubichandrap/subvision"
             target="_blank"
             rel="noreferrer"
             aria-label="Subvision on GitHub"
-            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+            className="inline-flex items-center gap-1.5 border-2 border-border bg-card px-3 py-1.5 font-mono text-xs font-bold uppercase tracking-wide text-foreground shadow-brutal-sm transition-all duration-100 hover:-translate-x-0.5 hover:-translate-y-0.5 hover:bg-primary hover:text-primary-foreground hover:shadow-brutal"
           >
             <Github className="h-4 w-4" />
             GitHub

--- a/client/components/process-details.tsx
+++ b/client/components/process-details.tsx
@@ -98,8 +98,8 @@ export function ProcessDetails({ processId }: { processId: string }) {
       </Link>
 
       <Card className="border-2 p-5">
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
+          <div className="min-w-0 max-w-xl flex-1">
             <h2 className="truncate font-display text-xl font-semibold">
               {process.filename || process.id}
             </h2>


### PR DESCRIPTION
## Summary
- Remove Reframe/Caption/Export eyebrow tag from landing hero
- Trim footer tagline to Subvision, restyle GitHub link as neobrutalist block
- Cap process header text at max-w-xl, widen row gap so title no longer crowds Download/Delete

## Test Plan
- [x] tsc --noEmit clean in client/