### PR TITLE
feat: save transcript edits and re-render

### DIFF
--- a/client/components/transcript-card.tsx
+++ b/client/components/transcript-card.tsx
@@ -4,9 +4,16 @@ import * as React from 'react';
 import { Loader2 } from 'lucide-react';
 
 import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { fetchSegments, type ProcessStage, type Segment } from '@/lib/api';
+import {
+  fetchSegments,
+  rerenderProcess,
+  saveSegments,
+  type ProcessStage,
+  type Segment,
+} from '@/lib/api';
 
 // Transcript card on the Process detail page: every segment with its text
 // and start/end time. Readable only after transcription — while
@@ -101,6 +108,10 @@ export function TranscriptCard({
   const [segments, setSegments] = React.useState<Segment[] | null>(null);
   const [fetchError, setFetchError] = React.useState<string | null>(null);
   const [draft, setDraft] = React.useState<DraftSegment[]>([]);
+  const [saving, setSaving] = React.useState(false);
+  const [rerendering, setRerendering] = React.useState(false);
+  const [savedNote, setSavedNote] = React.useState<string | null>(null);
+  const [actionError, setActionError] = React.useState<string | null>(null);
 
   // Refetch only when the polled stage moves (or the process changes) —
   // the existing per-process poll drives updates, nothing new polls here.
@@ -172,11 +183,68 @@ export function TranscriptCard({
   }
 
   const errors = validateSegments(draft);
+  const hasErrors = errors.some((e) => e.start ?? e.end ?? e.order);
 
   const updateRow = (index: number, patch: Partial<DraftSegment>) => {
     setDraft((prev) =>
       prev.map((row, i) => (i === index ? { ...row, ...patch } : row)),
     );
+  };
+
+  // Edited rows merge back onto the fetched segments: text plus parsed
+  // times, words ride along untouched (the server rescales word offsets
+  // into the edited window on save).
+  const toPayload = (): Segment[] =>
+    (segments ?? []).map((seg, i) => ({
+      ...seg,
+      text: draft[i]?.text ?? seg.text,
+      start:
+        draft[i] !== undefined && draft[i].start.trim() !== ''
+          ? Number(draft[i].start)
+          : seg.start,
+      end:
+        draft[i] !== undefined && draft[i].end.trim() !== ''
+          ? Number(draft[i].end)
+          : seg.end,
+    }));
+
+  const persistEdits = async (): Promise<Segment[]> => {
+    const saved = await saveSegments(processId, toPayload());
+    setSegments(saved);
+    setDraft(toDraft(saved));
+    return saved;
+  };
+
+  const handleSave = async () => {
+    setActionError(null);
+    setSavedNote(null);
+    setSaving(true);
+    try {
+      await persistEdits();
+      setSavedNote('Edits saved. Reloading the page shows them.');
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRerender = async () => {
+    setActionError(null);
+    setSavedNote(null);
+    setRerendering(true);
+    try {
+      // Save first so the re-render carries exactly what is on screen;
+      // the poll then moves the process through rendering to done.
+      await persistEdits();
+      await rerenderProcess(processId);
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : 'Re-render failed',
+      );
+    } finally {
+      setRerendering(false);
+    }
   };
 
   return (
@@ -248,6 +316,47 @@ export function TranscriptCard({
           );
         })}
       </ol>
+      {savedNote && (
+        <p className="mt-4 border-2 border-border bg-[#7df29a] p-2 text-sm font-bold text-[#141414]">
+          {savedNote}
+        </p>
+      )}
+      {actionError && (
+        <p
+          className="mt-4 border-2 border-border bg-destructive p-2 text-sm font-bold text-destructive-foreground"
+          role="alert"
+        >
+          {actionError}
+        </p>
+      )}
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button
+          onClick={() => {
+            void handleSave();
+          }}
+          disabled={saving || rerendering || hasErrors}
+        >
+          {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+          Save edits
+        </Button>
+        {stage === 'done' && (
+          <Button
+            variant="outline"
+            onClick={() => {
+              void handleRerender();
+            }}
+            disabled={saving || rerendering || hasErrors}
+          >
+            {rerendering && <Loader2 className="h-4 w-4 animate-spin" />}
+            Save and re-render
+          </Button>
+        )}
+      </div>
+      {hasErrors && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Fix the timing errors above before saving.
+        </p>
+      )}
     </Card>
   );
 }

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -113,6 +113,55 @@ export async function fetchSegments(id: string): Promise<Segment[]> {
   return data.segments;
 }
 
+type JSendFailBody = { status: 'fail'; data: Record<string, string> };
+
+function failMessage(body: string, fallback: string): string {
+  try {
+    const parsed = JSON.parse(body) as JSendFailBody;
+    const first = Object.values(parsed.data ?? {})[0];
+    return first ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+// Save writes edited segments; the server validates timing and rejects bad
+// rows with a fail message.
+export async function saveSegments(
+  id: string,
+  segments: Segment[],
+): Promise<Segment[]> {
+  const res = await fetch(
+    `${env.serverUrl}/jobs/${encodeURIComponent(normalizeJobId(id))}/segments`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ segments }),
+    },
+  );
+  if (res.ok) {
+    const body = (await res.json()) as { status: 'success'; data: { segments: Segment[] } };
+    return body.data.segments;
+  }
+  throw new Error(failMessage(await res.text(), `save returned ${res.status}`));
+}
+
+// Re-render publishes a fresh render job with the saved edits plus the
+// original Edit Spec, moving the process back through rendering to done.
+export async function rerenderProcess(id: string): Promise<Process> {
+  const res = await fetch(
+    `${env.serverUrl}/jobs/${encodeURIComponent(normalizeJobId(id))}/rerender`,
+    { method: 'POST' },
+  );
+  if (res.ok) {
+    const body = (await res.json()) as { status: 'success'; data: Process };
+    return body.data;
+  }
+  throw new Error(
+    failMessage(await res.text(), `re-render returned ${res.status}`),
+  );
+}
+
 // The URL the API provides for the rendered Output; the server streams it as
 // an attachment.
 export function downloadUrl(process: Process): string {

--- a/server/cmd/subvision/main.go
+++ b/server/cmd/subvision/main.go
@@ -187,7 +187,7 @@ func main() {
 	handler.RegisterTusd(r, tusdHandler)
 
 	// Register the status API over the Process lifecycle plus Process deletion
-	handler.RegisterJobs(r, jobs, jobs, objectStore, objectStore)
+	handler.RegisterJobs(r, jobs, jobs, jobs, vfxJobPublisher, objectStore, objectStore)
 
 	log.Println("Starting Subvision backend on port", env.Port)
 	if err := r.Run(":" + env.Port); err != nil {

--- a/server/internal/handler/jobs.go
+++ b/server/internal/handler/jobs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"path"
 	"strings"
@@ -14,8 +15,11 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/rubichandrap/subvision/server/internal/config"
+	"github.com/rubichandrap/subvision/server/internal/editspec"
 	"github.com/rubichandrap/subvision/server/internal/job"
 	"github.com/rubichandrap/subvision/server/internal/primitives"
+	"github.com/rubichandrap/subvision/server/internal/transcriber"
+	"github.com/rubichandrap/subvision/server/internal/vfxjob"
 )
 
 // JobReader reads the Process lifecycle; implemented by the job store.
@@ -23,11 +27,29 @@ type JobReader interface {
 	List() ([]job.Process, error)
 	Get(id string) (*job.Process, error)
 	Segments(id string) (string, error)
+	// EditSpec reads the upload's stored original Edit Spec, or empty when
+	// the upload carried none.
+	EditSpec(id string) (string, error)
 }
 
 // JobDeleter removes a Process record entirely; implemented by the job store.
 type JobDeleter interface {
 	Delete(id string) (bool, error)
+}
+
+// JobWriter persists edited Transcription Segments, reopens a done
+// Process for re-render, and fails it when the re-render never left;
+// implemented by the job store.
+type JobWriter interface {
+	SaveSegments(id, segmentsJSON string) error
+	Reopen(id string) (bool, error)
+	MarkFailed(id, reason string) (bool, error)
+}
+
+// RerenderPublisher publishes a fresh VFX Job for a re-render; implemented
+// by the vfx publisher.
+type RerenderPublisher interface {
+	Publish(job vfxjob.Job) error
 }
 
 // OutputOpener streams an Output object from storage.
@@ -70,8 +92,10 @@ func newProcessResponse(p *job.Process) processResponse {
 }
 
 // RegisterJobs exposes the status API over the Process lifecycle: reads for
-// the gallery, plus the one write — an immediate, best-effort Delete.
-func RegisterJobs(r *gin.Engine, jobs JobReader, deleter JobDeleter, outputs OutputOpener, cleaner ObjectCleaner) {
+// the gallery, segment edits with validation, a re-render action that
+// republishes the render job, plus the one write — an immediate,
+// best-effort Delete.
+func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDeleter, publisher RerenderPublisher, outputs OutputOpener, cleaner ObjectCleaner) {
 	r.GET("/jobs", func(c *gin.Context) {
 		processes, err := jobs.List()
 		if err != nil {
@@ -118,6 +142,141 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, deleter JobDeleter, outputs Out
 		primitives.JSendSuccess(c, gin.H{"segments": segments})
 	})
 
+	r.PUT("/jobs/:id/segments", func(c *gin.Context) {
+		id := c.Param("id")
+		process, err := jobs.Get(id)
+		if err != nil {
+			respondWithError(c, id, err)
+			return
+		}
+		if process.Stage != job.StageRendering && process.Stage != job.StageDone {
+			primitives.JSendFail(c, gin.H{"id": fmt.Sprintf("job %s is not editable in stage %s", id, process.Stage)}, http.StatusConflict)
+			return
+		}
+		var payload struct {
+			Segments json.RawMessage `json:"segments"`
+		}
+		if err := c.ShouldBindJSON(&payload); err != nil {
+			primitives.JSendFail(c, gin.H{"segments": "request body must carry a segments array"}, http.StatusBadRequest)
+			return
+		}
+		var segments []transcriber.Segment
+		if err := json.Unmarshal(payload.Segments, &segments); err != nil {
+			primitives.JSendFail(c, gin.H{"segments": "segments must decode as timed text"}, http.StatusBadRequest)
+			return
+		}
+		if err := validateSegmentTiming(segments); err != nil {
+			primitives.JSendFail(c, gin.H{"segments": err.Error()}, http.StatusBadRequest)
+			return
+		}
+		// Edited segments keep their whisper-original word timings at
+		// relative offsets, scaled into the edited window. Match by index:
+		// a row without a stored counterpart keeps its submitted words.
+		if stored, err := jobs.Segments(id); err == nil && len(stored) > 0 {
+			var original []transcriber.Segment
+			if json.Unmarshal([]byte(stored), &original) == nil {
+				for i := range segments {
+					if i >= len(original) {
+						break
+					}
+					if segments[i].Start != original[i].Start || segments[i].End != original[i].End {
+						segments[i].Words = rescaleWords(original[i], segments[i])
+					} else {
+						segments[i].Words = original[i].Words
+					}
+				}
+			}
+		}
+		raw, err := json.Marshal(segments)
+		if err != nil {
+			log.Printf("[Jobs] Failed to encode segments for job %s: %v", id, err)
+			primitives.JSendError(c, "failed to save segments", http.StatusInternalServerError, nil)
+			return
+		}
+		if err := writer.SaveSegments(id, string(raw)); err != nil {
+			log.Printf("[Jobs] Failed to save segments for job %s: %v", id, err)
+			primitives.JSendError(c, "failed to save segments", http.StatusInternalServerError, nil)
+			return
+		}
+		primitives.JSendSuccess(c, gin.H{"segments": segments})
+	})
+
+	// Re-render republishes a fresh VFX Job with the edited segments plus
+	// the upload's original Edit Spec, and moves the process back through
+	// rendering to done. The Output overwrites outputs/<id> in place.
+	r.POST("/jobs/:id/rerender", func(c *gin.Context) {
+		id := c.Param("id")
+		process, err := jobs.Get(id)
+		if err != nil {
+			respondWithError(c, id, err)
+			return
+		}
+		if process.Stage != job.StageDone {
+			primitives.JSendFail(c, gin.H{"id": fmt.Sprintf("job %s is not re-renderable in stage %s", id, process.Stage)}, http.StatusConflict)
+			return
+		}
+		stored, err := jobs.Segments(id)
+		if err != nil {
+			log.Printf("[Jobs] Failed to read segments for job %s: %v", id, err)
+			primitives.JSendError(c, "failed to read segments", http.StatusInternalServerError, nil)
+			return
+		}
+		var segments []transcriber.Segment
+		if len(stored) > 0 {
+			if err := json.Unmarshal([]byte(stored), &segments); err != nil {
+				log.Printf("[Jobs] Stored segments for job %s do not decode: %v", id, err)
+				primitives.JSendError(c, "stored segments are corrupt", http.StatusInternalServerError, nil)
+				return
+			}
+		}
+		rawSpec, err := jobs.EditSpec(id)
+		if err != nil {
+			log.Printf("[Jobs] Failed to read edit spec for job %s: %v", id, err)
+			primitives.JSendError(c, "failed to read edit spec", http.StatusInternalServerError, nil)
+			return
+		}
+		spec, err := editspec.Parse(rawSpec)
+		if err != nil {
+			log.Printf("[Jobs] Stored edit spec for job %s is invalid: %v", id, err)
+			primitives.JSendError(c, "stored edit spec is invalid", http.StatusInternalServerError, nil)
+			return
+		}
+		// Reopen first: a publish without a stage move would strand the
+		// render with the process still done, and MarkDone would then
+		// refuse the completion. A publish failure after reopen marks the
+		// job failed with its reason, never stranded.
+		reopened, err := writer.Reopen(id)
+		if err != nil {
+			log.Printf("[Jobs] Failed to reopen job %s: %v", id, err)
+			primitives.JSendError(c, "failed to reopen job", http.StatusInternalServerError, nil)
+			return
+		}
+		if !reopened {
+			primitives.JSendFail(c, gin.H{"id": fmt.Sprintf("job %s is not re-renderable in stage %s", id, process.Stage)}, http.StatusConflict)
+			return
+		}
+		rerender := vfxjob.Job{
+			UploadID:  id,
+			ObjectKey: config.ObjectPrefix + id,
+			Segments:  segments,
+			EditSpec:  spec,
+		}
+		if err := publisher.Publish(rerender); err != nil {
+			log.Printf("[Jobs] Failed to publish re-render for job %s: %v", id, err)
+			if _, markErr := writer.MarkFailed(id, fmt.Sprintf("re-render publish failed: %v", err)); markErr != nil {
+				log.Printf("[Jobs] Failed to fail job %s after publish error: %v", id, markErr)
+			}
+			primitives.JSendError(c, "failed to publish re-render", http.StatusInternalServerError, nil)
+			return
+		}
+		fresh, err := jobs.Get(id)
+		if err != nil {
+			log.Printf("[Jobs] Failed to read reopened job %s: %v", id, err)
+			primitives.JSendError(c, "failed to read reopened job", http.StatusInternalServerError, nil)
+			return
+		}
+		primitives.JSendSuccess(c, newProcessResponse(fresh))
+	})
 	r.GET("/jobs/:id/download", func(c *gin.Context) {
 		id := c.Param("id")
 		process, err := jobs.Get(id)
@@ -174,6 +333,53 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, deleter JobDeleter, outputs Out
 		}
 		c.Status(http.StatusNoContent)
 	})
+}
+
+// validateSegmentTiming rejects edited segments the render cannot use:
+// non-finite times, negative starts, ends at or before their start, and
+// segments that start before the previous one ends.
+func validateSegmentTiming(segments []transcriber.Segment) error {
+	for i, seg := range segments {
+		if !finiteTime(seg.Start) || !finiteTime(seg.End) {
+			return fmt.Errorf("segment %d must carry finite start and end times", i+1)
+		}
+		if seg.Start < 0 {
+			return fmt.Errorf("segment %d start must not be negative", i+1)
+		}
+		if seg.End <= seg.Start {
+			return fmt.Errorf("segment %d end must be after its start", i+1)
+		}
+		if i > 0 && seg.Start < segments[i-1].End {
+			return fmt.Errorf("segment %d must not start before segment %d ends", i+1, i)
+		}
+	}
+	return nil
+}
+
+// rescaleWords keeps a segment's whisper-original word timings at their
+// relative offsets, scaled into the edited window. Word timings are never
+// re-derived from scratch; a degenerate original window leaves words alone.
+func rescaleWords(original, edited transcriber.Segment) []transcriber.Word {
+	if len(original.Words) == 0 {
+		return original.Words
+	}
+	span := original.End - original.Start
+	if span <= 0 {
+		return original.Words
+	}
+	words := make([]transcriber.Word, len(original.Words))
+	for i, w := range original.Words {
+		words[i] = transcriber.Word{
+			Text:  w.Text,
+			Start: edited.Start + (w.Start-original.Start)/span*(edited.End-edited.Start),
+			End:   edited.Start + (w.End-original.Start)/span*(edited.End-edited.Start),
+		}
+	}
+	return words
+}
+
+func finiteTime(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
 }
 
 func respondWithError(c *gin.Context, id string, err error) {

--- a/server/internal/handler/jobs_rerender_test.go
+++ b/server/internal/handler/jobs_rerender_test.go
@@ -1,0 +1,277 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/rubichandrap/subvision/server/internal/db"
+	"github.com/rubichandrap/subvision/server/internal/job"
+	"github.com/rubichandrap/subvision/server/internal/vfxjob"
+)
+
+type fakeRerenderPublisher struct {
+	jobs []vfxjob.Job
+	err  error
+}
+
+func (f *fakeRerenderPublisher) Publish(job vfxjob.Job) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.jobs = append(f.jobs, job)
+	return nil
+}
+
+var errBrokerDown = errors.New("broker down")
+
+func newRerenderRouter(t *testing.T) (*gin.Engine, *job.Store, *fakeRerenderPublisher) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	store, err := job.NewStore(database)
+	if err != nil {
+		t.Fatalf("create job store: %v", err)
+	}
+	pub := &fakeRerenderPublisher{}
+	outputs := &fakeOutputs{body: "video bytes"}
+	cleaner := &fakeCleaner{}
+	router := gin.New()
+	RegisterJobs(router, store, store, store, pub, outputs, cleaner)
+	return router, store, pub
+}
+
+func doPut(t *testing.T, router *gin.Engine, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func doPost(t *testing.T, router *gin.Engine, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(nil))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func createDoneJob(t *testing.T, store *job.Store, id string) {
+	t.Helper()
+	if err := store.Create(id, "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	const stored = `[{"start":1.5,"end":2.5,"text":"hello","words":[{"text":"hello","start":1.6,"end":2.4}]}]`
+	if err := store.SaveSegments(id, stored); err != nil {
+		t.Fatalf("save segments: %v", err)
+	}
+	if recorded, err := store.MarkRendering(id); err != nil || !recorded {
+		t.Fatalf("mark rendering: recorded=%v err=%v", recorded, err)
+	}
+	if recorded, err := store.MarkDone(id, "outputs/"+id); err != nil || !recorded {
+		t.Fatalf("mark done: recorded=%v err=%v", recorded, err)
+	}
+}
+
+func TestSaveSegmentsPersistsEdits(t *testing.T) {
+	router, store, _ := newRerenderRouter(t)
+	createDoneJob(t, store, "u1")
+
+	const edited = `{"segments":[{"start":1.0,"end":2.0,"text":"fixed","words":[]}]}`
+	rec := doPut(t, router, "/jobs/u1/segments", edited)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT /jobs/u1/segments = %d: %s", rec.Code, rec.Body)
+	}
+
+	got, err := store.Segments("u1")
+	if err != nil {
+		t.Fatalf("read segments: %v", err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+		t.Fatalf("stored segments not JSON: %v", err)
+	}
+	if len(decoded) != 1 || decoded[0]["text"] != "fixed" {
+		t.Errorf("stored segments = %s, want the edited text", got)
+	}
+}
+
+func TestSaveSegmentsRescalesWordOffsets(t *testing.T) {
+	router, store, _ := newRerenderRouter(t)
+	createDoneJob(t, store, "u1")
+
+	// Original window 1.5-2.5 with word 1.6-2.4; edited window 1.0-3.0
+	// must keep the word at its relative offset, scaled: 1.2-2.8.
+	const edited = `{"segments":[{"start":1.0,"end":3.0,"text":"hello","words":[{"text":"hello","start":9.9,"end":9.9}]}]}`
+	if rec := doPut(t, router, "/jobs/u1/segments", edited); rec.Code != http.StatusOK {
+		t.Fatalf("PUT /jobs/u1/segments = %d: %s", rec.Code, rec.Body)
+	}
+	got, err := store.Segments("u1")
+	if err != nil {
+		t.Fatalf("read segments: %v", err)
+	}
+	var decoded []struct {
+		Words []struct {
+			Start float64 `json:"start"`
+			End   float64 `json:"end"`
+		} `json:"words"`
+	}
+	if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+		t.Fatalf("stored segments not JSON: %v", err)
+	}
+	if len(decoded) != 1 || len(decoded[0].Words) != 1 {
+		t.Fatalf("stored segments = %s, want one segment with one word", got)
+	}
+	w := decoded[0].Words[0]
+	const wantStart, wantEnd = 1.2, 2.8
+	if diff := w.Start - wantStart; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("word start = %v, want %v (relative offset scaled)", w.Start, wantStart)
+	}
+	if diff := w.End - wantEnd; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("word end = %v, want %v (relative offset scaled)", w.End, wantEnd)
+	}
+}
+
+func TestSaveSegmentsRejectsBadTiming(t *testing.T) {
+	router, store, _ := newRerenderRouter(t)
+	createDoneJob(t, store, "u1")
+
+	for name, body := range map[string]string{
+		"negative start":   `{"segments":[{"start":-1,"end":2,"text":"x","words":[]}]}`,
+		"end before start": `{"segments":[{"start":2,"end":1,"text":"x","words":[]}]}`,
+		"unordered":        `{"segments":[{"start":0,"end":5,"text":"a","words":[]},{"start":1,"end":2,"text":"b","words":[]}]}`,
+		"non-finite":       `{"segments":[{"start":"soon","end":2,"text":"x","words":[]}]}`,
+		"malformed json":   `{"segments":[}`,
+	} {
+		rec := doPut(t, router, "/jobs/u1/segments", body)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: PUT = %d, want 400 (%s)", name, rec.Code, rec.Body)
+		}
+	}
+}
+
+func TestSaveSegmentsUnknownJobReturns404(t *testing.T) {
+	router, _, _ := newRerenderRouter(t)
+
+	rec := doPut(t, router, "/jobs/missing/segments", `{"segments":[]}`)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("PUT /jobs/missing/segments = %d, want 404", rec.Code)
+	}
+}
+
+func TestRerenderPublishesJobWithEditedSegments(t *testing.T) {
+	router, store, pub := newRerenderRouter(t)
+	createDoneJob(t, store, "u1")
+
+	const spec = `{"trim":{"start":2,"end":9},"frame":{"preset":"9:16","ratio":0.5625,"zoom":1,"panX":0,"panY":0},"animation":"karaoke"}`
+	if err := store.SaveEditSpec("u1", spec); err != nil {
+		t.Fatalf("save edit spec: %v", err)
+	}
+	const edited = `{"segments":[{"start":1.0,"end":2.0,"text":"fixed","words":[]}]}`
+	if rec := doPut(t, router, "/jobs/u1/segments", edited); rec.Code != http.StatusOK {
+		t.Fatalf("PUT segments = %d: %s", rec.Code, rec.Body)
+	}
+
+	rec := doPost(t, router, "/jobs/u1/rerender")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("POST /jobs/u1/rerender = %d: %s", rec.Code, rec.Body)
+	}
+
+	got, err := store.Get("u1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Stage != job.StageRendering {
+		t.Errorf("stage = %q, want rendering", got.Stage)
+	}
+
+	if len(pub.jobs) != 1 {
+		t.Fatalf("expected one published vfx job, got %d", len(pub.jobs))
+	}
+	rerender := pub.jobs[0]
+	if rerender.UploadID != "u1" {
+		t.Errorf("UploadID = %q, want u1", rerender.UploadID)
+	}
+	if rerender.ObjectKey != "uploads/u1" {
+		t.Errorf("ObjectKey = %q, want uploads/u1", rerender.ObjectKey)
+	}
+	if len(rerender.Segments) != 1 || rerender.Segments[0].Text != "fixed" {
+		t.Errorf("rerender must carry edited segments: %+v", rerender.Segments)
+	}
+	if rerender.EditSpec == nil || rerender.EditSpec.Animation != "karaoke" {
+		t.Errorf("rerender must carry the original edit spec: %+v", rerender.EditSpec)
+	}
+}
+
+func TestRerenderWithoutEditsRepublishesStoredSegments(t *testing.T) {
+	router, store, pub := newRerenderRouter(t)
+	createDoneJob(t, store, "u1")
+
+	if rec := doPost(t, router, "/jobs/u1/rerender"); rec.Code != http.StatusOK {
+		t.Fatalf("POST /jobs/u1/rerender = %d: %s", rec.Code, rec.Body)
+	}
+	if len(pub.jobs) != 1 {
+		t.Fatalf("expected one published vfx job, got %d", len(pub.jobs))
+	}
+	rerender := pub.jobs[0]
+	if len(rerender.Segments) != 1 || rerender.Segments[0].Text != "hello" {
+		t.Errorf("unedited re-render must carry the stored segments: %+v", rerender.Segments)
+	}
+	if rerender.EditSpec != nil {
+		t.Errorf("unedited re-render without a spec must carry nil spec: %+v", rerender.EditSpec)
+	}
+	if got, err := store.Get("u1"); err != nil || got.Stage != job.StageRendering {
+		t.Errorf("stage must be rendering after re-render (got %+v, err %v)", got, err)
+	}
+}
+
+func TestRerenderPublishFailureFailsJob(t *testing.T) {
+	router, store, pub := newRerenderRouter(t)
+	createDoneJob(t, store, "u1")
+	pub.err = errBrokerDown
+
+	if rec := doPost(t, router, "/jobs/u1/rerender"); rec.Code != http.StatusInternalServerError {
+		t.Fatalf("POST /jobs/u1/rerender = %d, want 500 (%s)", rec.Code, rec.Body)
+	}
+	got, err := store.Get("u1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Stage != job.StageFailed {
+		t.Errorf("stage = %q, want failed (never stranded in rendering)", got.Stage)
+	}
+	if got.Reason == "" {
+		t.Error("failed re-render must surface its reason")
+	}
+}
+
+func TestRerenderRefusesNonDone(t *testing.T) {
+	router, store, pub := newRerenderRouter(t)
+	if err := store.Create("u1", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if rec := doPost(t, router, "/jobs/u1/rerender"); rec.Code != http.StatusConflict {
+		t.Errorf("POST rerender of in-flight job = %d, want 409", rec.Code)
+	}
+	if rec := doPost(t, router, "/jobs/missing/rerender"); rec.Code != http.StatusNotFound {
+		t.Errorf("POST rerender of unknown job = %d, want 404", rec.Code)
+	}
+	if len(pub.jobs) != 0 {
+		t.Errorf("refused re-render must not publish, got %d jobs", len(pub.jobs))
+	}
+}

--- a/server/internal/handler/jobs_test.go
+++ b/server/internal/handler/jobs_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/rubichandrap/subvision/server/internal/db"
 	"github.com/rubichandrap/subvision/server/internal/job"
+	"github.com/rubichandrap/subvision/server/internal/vfxjob"
 )
 
 type fakeOutputs struct {
@@ -29,6 +31,14 @@ func (f *fakeOutputs) Open(ctx context.Context, key string) (io.ReadCloser, int6
 
 type fakeCleaner struct {
 	deleted []string
+}
+
+// nilPublisher refuses every re-render publish; for routers whose tests
+// never touch the re-render endpoint.
+type nilPublisher struct{}
+
+func (nilPublisher) Publish(job vfxjob.Job) error {
+	return errors.New("re-render not wired in this test router")
 }
 
 func (f *fakeCleaner) Delete(ctx context.Context, prefix string) error {
@@ -53,7 +63,7 @@ func newJobsRouter(t *testing.T) (*gin.Engine, *job.Store, *fakeOutputs, *fakeCl
 	outputs := &fakeOutputs{body: "video bytes"}
 	cleaner := &fakeCleaner{}
 	router := gin.New()
-	RegisterJobs(router, store, store, outputs, cleaner)
+	RegisterJobs(router, store, store, store, nilPublisher{}, outputs, cleaner)
 	return router, store, outputs, cleaner
 }
 

--- a/server/internal/job/job.go
+++ b/server/internal/job/job.go
@@ -54,9 +54,15 @@ type Process struct {
 type Tracker interface {
 	MarkTranscribing(uploadID string) (bool, error)
 	MarkRendering(uploadID string) (bool, error)
+	// Reopen moves a done job back to rendering for a re-render, bypassing
+	// the terminal-stage guard that mark enforces for the normal pipeline.
+	Reopen(uploadID string) (bool, error)
 	// SaveSegments persists the whisper-original Transcription Segments for
 	// an upload as JSON, so they outlive the queue message.
 	SaveSegments(uploadID, segmentsJSON string) error
+	// SaveEditSpec persists the upload's original Edit Spec as JSON, so a
+	// re-render reuses it. Empty when the upload carried no spec.
+	SaveEditSpec(uploadID, specJSON string) error
 }
 
 type Store struct {
@@ -87,6 +93,16 @@ func NewStore(db *sql.DB) (*Store, error) {
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create job_segments table: %w", err)
+	}
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS job_edit_specs (
+			job_id     TEXT PRIMARY KEY,
+			spec       TEXT NOT NULL DEFAULT '',
+			updated_at TEXT NOT NULL
+		)
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create job_edit_specs table: %w", err)
 	}
 	return &Store{db: db}, nil
 }
@@ -137,6 +153,26 @@ func (s *Store) MarkRendering(uploadID string) (bool, error) {
 	return s.mark(uploadID, StageRendering, "", "")
 }
 
+// Reopen moves a done job back to rendering for a re-render. The normal
+// mark refuses terminal stages, so this runs its own statement: only done
+// reopens, failed stays failed, unknown ids report false.
+func (s *Store) Reopen(uploadID string) (bool, error) {
+	res, err := s.db.Exec(
+		`UPDATE jobs SET stage = ?, reason = ?, updated_at = ?
+		 WHERE id = ? AND stage = ?`,
+		string(StageRendering), "", time.Now().UTC().Format(time.RFC3339), uploadID,
+		string(StageDone),
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to reopen job %s: %w", uploadID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("failed to reopen job %s: %w", uploadID, err)
+	}
+	return affected > 0, nil
+}
+
 // MarkDone records the completed Output of a rendered job.
 func (s *Store) MarkDone(uploadID, outputKey string) (bool, error) {
 	return s.mark(uploadID, StageDone, "", outputKey)
@@ -147,11 +183,15 @@ func (s *Store) MarkFailed(uploadID, reason string) (bool, error) {
 	return s.mark(uploadID, StageFailed, reason, "")
 }
 
-// Delete removes the process row entirely, with its stored segments. It
+// Delete removes the process row entirely, with its stored segments and
+// edit spec. It
 // reports whether a row was deleted; deleting an unknown id is not an error.
 func (s *Store) Delete(id string) (bool, error) {
 	if _, err := s.db.Exec(`DELETE FROM job_segments WHERE job_id = ?`, id); err != nil {
 		return false, fmt.Errorf("failed to delete segments for job %s: %w", id, err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM job_edit_specs WHERE job_id = ?`, id); err != nil {
+		return false, fmt.Errorf("failed to delete edit spec for job %s: %w", id, err)
 	}
 	res, err := s.db.Exec(`DELETE FROM jobs WHERE id = ?`, id)
 	if err != nil {
@@ -177,6 +217,35 @@ func (s *Store) SaveSegments(uploadID, segmentsJSON string) error {
 		return fmt.Errorf("failed to save segments for job %s: %w", uploadID, err)
 	}
 	return nil
+}
+
+// SaveEditSpec stores the upload's original Edit Spec as raw JSON, so a
+// re-render reuses it. An empty raw means "no edit" and clears any stored
+// copy.
+func (s *Store) SaveEditSpec(uploadID, specJSON string) error {
+	_, err := s.db.Exec(
+		`INSERT INTO job_edit_specs (job_id, spec, updated_at) VALUES (?, ?, ?)
+		 ON CONFLICT(job_id) DO UPDATE SET spec = excluded.spec, updated_at = excluded.updated_at`,
+		uploadID, specJSON, time.Now().UTC().Format(time.RFC3339),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to save edit spec for job %s: %w", uploadID, err)
+	}
+	return nil
+}
+
+// EditSpec returns the stored original Edit Spec JSON, or empty when the
+// upload carried none. Reading an unknown id is not an error.
+func (s *Store) EditSpec(uploadID string) (string, error) {
+	var spec string
+	err := s.db.QueryRow(`SELECT spec FROM job_edit_specs WHERE job_id = ?`, uploadID).Scan(&spec)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to read edit spec for job %s: %w", uploadID, err)
+	}
+	return spec, nil
 }
 
 // Segments returns the stored Transcription Segments JSON for an upload, or

--- a/server/internal/job/job_reopen_test.go
+++ b/server/internal/job/job_reopen_test.go
@@ -1,0 +1,128 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/rubichandrap/subvision/server/internal/db"
+)
+
+func TestReopenMovesDoneToRendering(t *testing.T) {
+	handle, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { handle.Close() })
+	store, err := NewStore(handle)
+	if err != nil {
+		t.Fatalf("create job store: %v", err)
+	}
+
+	if err := store.Create("u1", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if recorded, err := store.MarkDone("u1", "outputs/u1"); err != nil || !recorded {
+		t.Fatalf("mark done: recorded=%v err=%v", recorded, err)
+	}
+
+	reopened, err := store.Reopen("u1")
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if !reopened {
+		t.Fatal("reopen of a done job must take effect")
+	}
+	got, err := store.Get("u1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Stage != StageRendering {
+		t.Errorf("stage = %q, want %q", got.Stage, StageRendering)
+	}
+}
+
+func TestReopenRefusesNonDone(t *testing.T) {
+	handle, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { handle.Close() })
+	store, err := NewStore(handle)
+	if err != nil {
+		t.Fatalf("create job store: %v", err)
+	}
+
+	if err := store.Create("u1", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if recorded, err := store.MarkTranscribing("u1"); err != nil || !recorded {
+		t.Fatalf("mark transcribing: recorded=%v err=%v", recorded, err)
+	}
+	if reopened, err := store.Reopen("u1"); err != nil || reopened {
+		t.Errorf("reopen of an in-flight job must not take effect: reopened=%v err=%v", reopened, err)
+	}
+
+	if err := store.Create("u2", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if recorded, err := store.MarkFailed("u2", "boom"); err != nil || !recorded {
+		t.Fatalf("mark failed: recorded=%v err=%v", recorded, err)
+	}
+	if reopened, err := store.Reopen("u2"); err != nil || reopened {
+		t.Errorf("reopen of a failed job must not take effect: reopened=%v err=%v", reopened, err)
+	}
+
+	if reopened, err := store.Reopen("missing"); err != nil || reopened {
+		t.Errorf("reopen of an unknown id must not take effect: reopened=%v err=%v", reopened, err)
+	}
+}
+
+func TestEditSpecRoundTrip(t *testing.T) {
+	handle, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { handle.Close() })
+	store, err := NewStore(handle)
+	if err != nil {
+		t.Fatalf("create job store: %v", err)
+	}
+
+	if err := store.Create("u1", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const raw = `{"trim":{"start":2,"end":9},"frame":{"preset":"9:16","ratio":0.5625,"zoom":1,"panX":0,"panY":0},"animation":"karaoke"}`
+	if err := store.SaveEditSpec("u1", raw); err != nil {
+		t.Fatalf("save edit spec: %v", err)
+	}
+	got, err := store.EditSpec("u1")
+	if err != nil {
+		t.Fatalf("read edit spec: %v", err)
+	}
+	if got != raw {
+		t.Errorf("edit spec = %q, want %q", got, raw)
+	}
+}
+
+func TestEditSpecEmptyWhenNoneStored(t *testing.T) {
+	handle, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { handle.Close() })
+	store, err := NewStore(handle)
+	if err != nil {
+		t.Fatalf("create job store: %v", err)
+	}
+
+	if err := store.Create("u1", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := store.EditSpec("u1")
+	if err != nil {
+		t.Fatalf("read edit spec: %v", err)
+	}
+	if got != "" {
+		t.Errorf("edit spec = %q, want empty", got)
+	}
+}

--- a/server/internal/processor/processor.go
+++ b/server/internal/processor/processor.go
@@ -146,6 +146,19 @@ func (p *Processor) ProcessUploadedFile(uploadID, objectKey string, spec *editsp
 		} else if err := p.lifecycle.SaveSegments(uploadID, string(payload)); err != nil {
 			log.Printf("[Processor] %v", err)
 		}
+		// Persist the original Edit Spec alongside, so a later re-render
+		// reuses it. A missing spec stores empty ("no edit").
+		var raw []byte
+		if spec != nil {
+			var err error
+			raw, err = json.Marshal(spec)
+			if err != nil {
+				log.Printf("[Processor] Failed to encode edit spec for upload %s: %v", uploadID, err)
+			}
+		}
+		if err := p.lifecycle.SaveEditSpec(uploadID, string(raw)); err != nil {
+			log.Printf("[Processor] %v", err)
+		}
 	}
 	if err := p.publisher.Publish(job); err != nil {
 		return fmt.Errorf("failed to publish vfx job for upload %s: %w", uploadID, err)

--- a/server/internal/processor/processor_test.go
+++ b/server/internal/processor/processor_test.go
@@ -214,6 +214,14 @@ func (f *fakeLifecycle) SaveSegments(uploadID, segmentsJSON string) error {
 	return nil
 }
 
+func (f *fakeLifecycle) SaveEditSpec(uploadID, specJSON string) error {
+	return nil
+}
+
+func (f *fakeLifecycle) Reopen(uploadID string) (bool, error) {
+	return true, nil
+}
+
 func TestProcessUploadedFilePublishErrorSurfaces(t *testing.T) {
 	pub := &fakePublisher{err: errors.New("broker down")}
 	proc := newTestProcessor(pub, &fakeStore{}, func(transcriber.Settings, string) ([]transcriber.Segment, error) {


### PR DESCRIPTION
## Summary
PUT /jobs/:id/segments validates timing and rescales word offsets into edited windows. POST /jobs/:id/rerender reopens done to rendering then publishes a fresh VFX Job with edited segments plus the stored original Edit Spec. Publish failure marks the job failed with its reason, never stranded. Edit Spec now persisted per upload at transcribe time. Client card gains Save and Save+re-render.

## Test Plan
- [x] go test ./internal/... green (whisper env)
- [x] client tsc + pnpm build pass
- [ ] save edits, reload shows them
- [ ] re-render moves done to rendering to done, same download link
- [ ] failed re-render surfaces reason

Closes #35