### PR TITLE
feat(job): collapse Process lifecycle and transcript orchestration into deep Job module

### DIFF
--- a/.scratch/deepen-job-module/issues/01-pure-segment-timing-validation-and-word-rescaling.md
+++ b/.scratch/deepen-job-module/issues/01-pure-segment-timing-validation-and-word-rescaling.md
@@ -1,0 +1,21 @@
+Promoted: #46
+
+## Parent
+
+Part of #45
+
+## What to build
+
+The domain rules for checking segment timing and scaling word timestamps into edited windows move into pure, in-process functions in the transcriber module alongside the Segment and Word types. Non-finite times, negative starts, non-positive durations, and overlapping or out-of-order segment bounds are rejected with clear validation errors. Word timestamps inside an edited segment are scaled proportionally into the new window while preserving original relative offsets.
+
+## Acceptance criteria
+
+- [x] `transcriber.ValidateSegmentTiming` rejects non-finite values, negative starts, `end <= start`, and non-chronological overlap with a typed error
+- [x] Valid segment sequences pass validation without error
+- [x] `transcriber.RescaleWords` proportionally scales `TimedWord` timestamps into the edited segment window based on original whisper timestamps
+- [x] Words outside modified windows or with unchanged segment boundaries retain their original timestamps
+- [x] Pure unit tests cover all validation boundaries and word scaling calculations without database or HTTP harnesses
+
+## Blocked by
+
+- None — can start immediately.

--- a/.scratch/deepen-job-module/issues/02-deepen-job-module-lifecycle-and-side-effect-ports.md
+++ b/.scratch/deepen-job-module/issues/02-deepen-job-module-lifecycle-and-side-effect-ports.md
@@ -1,0 +1,24 @@
+Promoted: #47
+
+## Parent
+
+Part of #45
+
+## What to build
+
+The Job module directly owns the Process lifecycle state machine, transcript persistence, re-render execution, and deletion cleanup behind a cohesive interface with internal SQLite and injected ports. Saving segments validates timing and rescales words before persisting to the database. Re-rendering a completed process transitions it back to rendering, publishes a fresh VFX Job to RabbitMQ with the stored Edit Spec, and rolls back to failed if publishing fails. Process deletion immediately removes all database records and triggers best-effort storage cleanup for upload and output objects per ADR-0004.
+
+## Acceptance criteria
+
+- [ ] `job.Store` accepts injected `VfxPublisher` and `ObjectCleaner` ports at construction
+- [ ] `job.Store.SaveSegments` enforces that the Process is in `rendering` or `done` stage, validates timings, rescales words against whisper originals, and saves to `job_segments`
+- [ ] `job.Store.SaveSegments` returns a typed stage conflict error if the process is in an uneditable stage
+- [ ] `job.Store.Rerender` verifies the Process is in `done` stage, loads stored segments and Edit Spec, transitions stage to `rendering`, and publishes a fresh `vfxjob.Job`
+- [ ] If re-render publish fails, `job.Store.Rerender` transitions the process to `failed` with the error reason and returns an error
+- [ ] `job.Store.Delete` deletes database rows first (`jobs`, `job_segments`, `job_edit_specs`), then invokes `ObjectCleaner` for upload and output prefixes best-effort per ADR-0004
+- [ ] Storage cleanup errors during deletion are logged but do not fail the `Delete` operation
+- [ ] Domain tests verify save, re-render, rollback, and deletion directly across the `job.Store` interface using in-memory SQLite and fake ports
+
+## Blocked by
+
+- #46 — Pure segment timing validation and word rescaling in transcriber

--- a/.scratch/deepen-job-module/issues/03-collapse-http-handler-seam-and-migrate-wiring.md
+++ b/.scratch/deepen-job-module/issues/03-collapse-http-handler-seam-and-migrate-wiring.md
@@ -1,0 +1,22 @@
+Promoted: #48
+
+## Parent
+
+Part of #45
+
+## What to build
+
+The HTTP transport handler collapses its six fragmented interfaces into two (ProcessManager and OutputOpener), becoming a thin Gin adapter that unmarshals JSON, delegates to the Job module, and maps domain errors to HTTP status codes (400 for validation errors, 404 for missing jobs, 409 for stage conflicts). Dependency wiring in main.go passes the unified job.Store directly. The 277-line HTTP-coupled integration test file is replaced by lightweight route-mapping smoke tests.
+
+## Acceptance criteria
+
+- [ ] `handler.RegisterJobs` accepts only `ProcessManager` and `OutputOpener` interfaces
+- [ ] Six shallow interfaces (`JobReader`, `JobWriter`, `JobDeleter`, `RerenderPublisher`, etc.) are removed from `handler/jobs.go`
+- [ ] HTTP handler delegates segment saving, re-rendering, and deletion directly to `ProcessManager`
+- [ ] Domain errors are mapped cleanly to HTTP status codes (400 for `ValidationError`, 404 for `ErrNotFound`, 409 for `ErrStageConflict`)
+- [ ] `server/cmd/subvision/main.go` wires `job.Store` directly without passing the same instance repeatedly to fragmented interfaces
+- [ ] `jobs_rerender_test.go` HTTP tests are replaced with thin route-mapping smoke tests; all server tests pass green (`./test.sh`)
+
+## Blocked by
+
+- #47 — Deepen Job module with side-effect ports, segment editing, re-render, and deletion

--- a/.scratch/deepen-job-module/spec.md
+++ b/.scratch/deepen-job-module/spec.md
@@ -1,0 +1,70 @@
+Promoted: #45
+
+# Spec: Collapse Process lifecycle and transcript orchestration into a deep Job module
+
+## Problem Statement
+
+The Process lifecycle and transcript orchestration are split across the codebase. While ADR-0002 established that `internal/job` owns the Process lifecycle, the Job module was left as a shallow SQL repository exposing 13 individual database operations. The HTTP transport handler was forced to absorb domain orchestration: validating segment timing invariants, rescaling word offsets against stored originals, managing stage checks for editing and re-rendering, publishing re-render jobs to RabbitMQ with rollback on failure, and coordinating database row deletion with storage object cleanup.
+
+This leaks domain rules into HTTP routing, requires the HTTP handler to take six separate interfaces, causes `main.go` to inject the same dependencies multiple times through artificial interfaces, and forces domain verification tests to spin up an HTTP router, format fake requests, and parse JSON responses.
+
+## Solution
+
+Deepen the Job module so it directly owns the Process lifecycle, transcript edits, re-render coordination, and deletion cleanup behind a cohesive interface. The HTTP transport handler becomes a thin adapter that only parses HTTP requests, calls the Job module, and writes HTTP responses. Pure mathematical transformations on Transcription Segments (timing validation, word rescaling) move to the transcriber module alongside the domain types. Side-effect ports for publishing render jobs and cleaning storage objects are injected into the Job module, allowing domain tests to cross the Job interface directly using an in-memory SQLite store and fake publisher without HTTP routing ceremony.
+
+## User Stories
+
+1. As a video owner, I want my edited transcript segments validated for valid positive times and chronological order, so that malformed timing cannot corrupt subtitle rendering.
+2. As a video owner, I want words inside my edited segments to maintain their relative spoken timing, so that moving a segment window doesn't destroy karaoke word synchronization.
+3. As a video owner, I want to re-render my video after editing transcript segments, so that my corrections are burned into a new output video.
+4. As a video owner, I want re-rendering to be rejected if my job is not in the done stage, so that I cannot re-render an in-flight or failed process.
+5. As a video owner, I want a failed re-render publish to mark my process as failed with a clear reason, so that I am never left waiting on a phantom render.
+6. As a video owner, I want deleting a process to remove its record immediately, so that the gallery updates without waiting on storage operations.
+7. As a video owner, I want deleting a process to clean up uploaded and rendered video files best-effort, so that deleted videos do not accumulate storage waste.
+8. As a video owner, I want storage cleanup failures during deletion logged but ignored, so that a transient storage glitch never prevents me from deleting an unwanted process.
+9. As a maintainer, I want the Job module to own all Process state transitions, so that the status state machine has exactly one source of truth.
+10. As a maintainer, I want transcript validation and word offset rescaling to live as pure functions in the transcriber module, so that mathematical timing transformations are isolated from database and network I/O.
+11. As a maintainer, I want the HTTP transport handler to act as a thin adapter, so that transport concerns (routing, status codes, JSON serialization) never mix with domain logic.
+12. As a maintainer, I want domain failures exposed as typed sentinel errors, so that the HTTP adapter maps them to HTTP status codes without the domain module knowing about HTTP.
+13. As a maintainer, I want six shallow handler interfaces collapsed into two clean interfaces, so that wiring in main.go does not pass the same instances repeatedly through fragmented interfaces.
+14. As a maintainer, I want Process deletion to delete database records first before cleaning storage, so that UI state is immediately consistent per ADR-0004.
+15. As a test author, I want to verify Process lifecycle, transcript saving, and re-rendering directly against the Job module interface, so that tests do not require spinning up an HTTP server or parsing HTTP responses.
+16. As a test author, I want to test segment timing validation and word rescaling with pure unit tests, so that timing math tests execute instantly without database setup.
+17. As a test author, I want the Job module testable against an in-memory SQLite database, so that tests remain fast, hermetic, and independent of disk state.
+18. As the client application, I want transcript save requests to return 400 with validation details when timings are invalid, so that editing errors can be shown to the user.
+19. As the client application, I want transcript save requests to return 409 when the process is in a non-editable stage, so that late edits on in-flight processes are refused cleanly.
+20. As the client application, I want re-render requests to return 409 when the process is not done, so that invalid re-render triggers fail predictably.
+
+## Implementation Decisions
+
+- The Job module directly encapsulates SQLite access, the Process lifecycle state machine, transcript persistence, re-render coordination, and deletion cleanup.
+- External side-effect dependencies are defined as injected ports on the Job module: a publisher port for enqueueing VFX Jobs and an object cleaner port for erasing storage prefixes.
+- Pure functions for segment timing validation (non-finite values, negative starts, non-positive durations, and overlapping/out-of-order bounds) and proportional word timestamp rescaling live in the transcriber module alongside the domain types.
+- The HTTP handler exposes only routing and translation: it consumes a single Process manager interface and an output streaming interface. The six fragmented interfaces are removed.
+- Domain errors are returned as typed sentinel and value errors (not-found, stage-conflict, validation-failure); the HTTP handler translates these into corresponding HTTP status codes (404, 409, 400).
+- Re-render coordination: loads the stored segments and original Edit Spec, reopens the Process to rendering, publishes the VFX Job, and rolls back the Process to failed if publishing fails.
+- Deletion coordination: removes the database records first (Process, segments, edit spec), then invokes the storage cleaner best-effort for upload and output prefixes, logging any storage errors without failing the operation, adhering strictly to ADR-0004.
+- All database schema tables and queries remain private implementation details of the Job module.
+
+## Testing Decisions
+
+- Good tests check external behavior through the module interface, never internal implementation details (such as specific SQL queries or unexported helper functions).
+- Primary test surface: the Job module interface, using an in-memory SQLite database (`:memory:`) and an in-memory fake publisher.
+- Pure functions in the transcriber module (`ValidateSegmentTiming`, `RescaleWords`) are tested via deterministic unit tests across edge cases (zero duration, negative offsets, proportional scaling).
+- HTTP handler tests are reduced to lightweight route-mapping smoke tests checking that HTTP status codes and payloads map correctly to/from the domain interface.
+- Existing tests in the HTTP test file that tested domain validation, word rescaling, and re-render rollback through HTTP requests are replaced by direct domain tests on the Job module.
+- Prior art: existing in-memory SQLite tests in `server/internal/job/job_reopen_test.go` and `job_segments_test.go`.
+
+## Out of Scope
+
+- Modifying the VFX service or the Remotion rendering templates.
+- Changing the wire contract for VFX Jobs on RabbitMQ.
+- Client-side changes to the Transcript card or Process gallery.
+- Soft deletes or process archiving (deletion remains immediate and irreversible per ADR-0004).
+- Editing the original Edit Spec during re-rendering (the stored spec is reused as-is).
+
+## Further Notes
+
+- Originates from Candidate 1 of the 2026-09-07 architecture review.
+- Aligns with and reinforces ADR-0002 (SQLite for job state) and ADR-0004 (Immediate best-effort delete).
+- `CONTEXT.md` updated to reflect that a Process allows transcript editing and re-rendering.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,8 +50,12 @@ the Next.js client uploads videos with tus.
   is Cancel, a separate concept not yet built (see ADR-0004).
 - **Process** — the client-facing lifecycle of a job (uploaded →
   transcribing → rendering → done/failed). Real server-side state, owned by
-  the server's job module, exposed read-only by the status API
-  (`GET /jobs`, `GET /jobs/:id`); the client polls it and never invents state.
+  the server's job module; the client polls its status, edits its
+  Transcription Segments, and can trigger a Re-render.
+- **Re-render** — republishing a fresh VFX Job for a completed Process using
+  edited Transcription Segments and the stored original Edit Spec,
+  transitioning the Process from done back to rendering. The rendered Output
+  replaces `outputs/<id>` in place.
 - **Timing Drift** — a Timed Word appearing before it is spoken, or late by a
   fraction of a second. A decode-timing miss, not a missing word or wrong text.
 

--- a/server/cmd/subvision/main.go
+++ b/server/cmd/subvision/main.go
@@ -186,7 +186,7 @@ func main() {
 	handler.RegisterTusd(r, tusdHandler)
 
 	// Register the status API over the Process lifecycle plus Process deletion
-	handler.RegisterJobs(r, jobs, jobs, jobs, vfxJobPublisher, objectStore, objectStore)
+	handler.RegisterJobs(r, jobs, objectStore)
 
 	log.Println("Starting Subvision backend on port", env.Port)
 	if err := r.Run(":" + env.Port); err != nil {

--- a/server/cmd/subvision/main.go
+++ b/server/cmd/subvision/main.go
@@ -57,17 +57,6 @@ func main() {
 	s3Client := s3.NewFromConfig(awsCfg)
 	objectStore := storage.New(s3Client, env.S3Bucket)
 
-	// Job state: the Process lifecycle, persisted so restarts don't lose it.
-	database, err := db.Open("data/subvision.db")
-	if err != nil {
-		log.Fatalf("Failed to open job database: %v", err)
-	}
-	defer database.Close()
-	jobs, err := job.NewStore(database)
-	if err != nil {
-		log.Fatalf("Failed to prepare job store: %v", err)
-	}
-
 	// Init RabbitMQ connection, publisher, and consumer
 	conn := rabbitmq.Connect(env.AmqpURL)
 	defer conn.Close()
@@ -76,6 +65,16 @@ func main() {
 	uploadJobPublisher := rabbitmq.NewUploadJobPublisher(conn)
 	vfxJobPublisher := rabbitmq.NewVfxJobPublisher(conn)
 
+	// Job state: the Process lifecycle, persisted so restarts don't lose it.
+	database, err := db.Open("data/subvision.db")
+	if err != nil {
+		log.Fatalf("Failed to open job database: %v", err)
+	}
+	defer database.Close()
+	jobs, err := job.NewStore(database, vfxJobPublisher, objectStore)
+	if err != nil {
+		log.Fatalf("Failed to prepare job store: %v", err)
+	}
 	// consumers
 	proc := processor.New(processor.Options{
 		Publisher:        vfxJobPublisher,

--- a/server/internal/handler/jobs.go
+++ b/server/internal/handler/jobs.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,55 +11,29 @@ import (
 	"strings"
 	"time"
 
+	"encoding/json"
+
 	"github.com/gin-gonic/gin"
-	"github.com/rubichandrap/subvision/server/internal/config"
-	"github.com/rubichandrap/subvision/server/internal/editspec"
 	"github.com/rubichandrap/subvision/server/internal/job"
 	"github.com/rubichandrap/subvision/server/internal/primitives"
 	"github.com/rubichandrap/subvision/server/internal/transcriber"
-	"github.com/rubichandrap/subvision/server/internal/vfxjob"
 )
 
-// JobReader reads the Process lifecycle; implemented by the job store.
-type JobReader interface {
+// ProcessManager is the unified port the HTTP handler depends on: it covers
+// the full Process lifecycle plus segment editing and re-render publishing.
+// Implemented by job.Store.
+type ProcessManager interface {
 	List() ([]job.Process, error)
 	Get(id string) (*job.Process, error)
 	Segments(id string) (string, error)
-	// EditSpec reads the upload's stored original Edit Spec, or empty when
-	// the upload carried none.
-	EditSpec(id string) (string, error)
-}
-
-// JobDeleter removes a Process record entirely; implemented by the job store.
-type JobDeleter interface {
+	SaveSegments(id string, segments []transcriber.Segment) ([]transcriber.Segment, error)
+	Rerender(id string) (*job.Process, error)
 	Delete(id string) (bool, error)
-}
-
-// JobWriter persists edited Transcription Segments, reopens a done
-// Process for re-render, and fails it when the re-render never left;
-// implemented by the job store.
-type JobWriter interface {
-	SaveOriginalSegments(id, segmentsJSON string) error
-	Reopen(id string) (bool, error)
-	MarkFailed(id, reason string) (bool, error)
-}
-
-// RerenderPublisher publishes a fresh VFX Job for a re-render; implemented
-// by the vfx publisher.
-type RerenderPublisher interface {
-	Publish(job vfxjob.Job) error
 }
 
 // OutputOpener streams an Output object from storage.
 type OutputOpener interface {
 	Open(ctx context.Context, key string) (io.ReadCloser, int64, error)
-}
-
-// ObjectCleaner deletes every stored object under a key prefix (the Upload
-// and the Output ride under `uploads/` and `outputs/`); implemented by the
-// storage client.
-type ObjectCleaner interface {
-	Delete(ctx context.Context, prefix string) error
 }
 
 type processResponse struct {
@@ -94,9 +67,9 @@ func newProcessResponse(p *job.Process) processResponse {
 // the gallery, segment edits with validation, a re-render action that
 // republishes the render job, plus the one write — an immediate,
 // best-effort Delete.
-func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDeleter, publisher RerenderPublisher, outputs OutputOpener, cleaner ObjectCleaner) {
+func RegisterJobs(r *gin.Engine, manager ProcessManager, outputs OutputOpener) {
 	r.GET("/jobs", func(c *gin.Context) {
-		processes, err := jobs.List()
+		processes, err := manager.List()
 		if err != nil {
 			log.Printf("[Jobs] Failed to list jobs: %v", err)
 			primitives.JSendError(c, "failed to list jobs", http.StatusInternalServerError, nil)
@@ -111,7 +84,7 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 
 	r.GET("/jobs/:id", func(c *gin.Context) {
 		id := c.Param("id")
-		process, err := jobs.Get(id)
+		process, err := manager.Get(id)
 		if err != nil {
 			respondWithError(c, id, err)
 			return
@@ -124,11 +97,11 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 	// process with nothing stored yet reads as an empty list.
 	r.GET("/jobs/:id/segments", func(c *gin.Context) {
 		id := c.Param("id")
-		if _, err := jobs.Get(id); err != nil {
+		if _, err := manager.Get(id); err != nil {
 			respondWithError(c, id, err)
 			return
 		}
-		stored, err := jobs.Segments(id)
+		stored, err := manager.Segments(id)
 		if err != nil {
 			log.Printf("[Jobs] Failed to read segments for job %s: %v", id, err)
 			primitives.JSendError(c, "failed to read segments", http.StatusInternalServerError, nil)
@@ -143,15 +116,6 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 
 	r.PUT("/jobs/:id/segments", func(c *gin.Context) {
 		id := c.Param("id")
-		process, err := jobs.Get(id)
-		if err != nil {
-			respondWithError(c, id, err)
-			return
-		}
-		if process.Stage != job.StageRendering && process.Stage != job.StageDone {
-			primitives.JSendFail(c, gin.H{"id": fmt.Sprintf("job %s is not editable in stage %s", id, process.Stage)}, http.StatusConflict)
-			return
-		}
 		var payload struct {
 			Segments json.RawMessage `json:"segments"`
 		}
@@ -164,40 +128,12 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 			primitives.JSendFail(c, gin.H{"segments": "segments must decode as timed text"}, http.StatusBadRequest)
 			return
 		}
-		if err := transcriber.ValidateSegmentTiming(segments); err != nil {
-			primitives.JSendFail(c, gin.H{"segments": err.Error()}, http.StatusBadRequest)
-			return
-		}
-		// Edited segments keep their whisper-original word timings at
-		// relative offsets, scaled into the edited window. Match by index:
-		// a row without a stored counterpart keeps its submitted words.
-		if stored, err := jobs.Segments(id); err == nil && len(stored) > 0 {
-			var original []transcriber.Segment
-			if json.Unmarshal([]byte(stored), &original) == nil {
-				for i := range segments {
-					if i >= len(original) {
-						break
-					}
-					if segments[i].Start != original[i].Start || segments[i].End != original[i].End {
-						segments[i].Words = transcriber.RescaleWords(original[i], segments[i])
-					} else {
-						segments[i].Words = original[i].Words
-					}
-				}
-			}
-		}
-		raw, err := json.Marshal(segments)
+		saved, err := manager.SaveSegments(id, segments)
 		if err != nil {
-			log.Printf("[Jobs] Failed to encode segments for job %s: %v", id, err)
-			primitives.JSendError(c, "failed to save segments", http.StatusInternalServerError, nil)
+			respondWithError(c, id, err)
 			return
 		}
-		if err := writer.SaveOriginalSegments(id, string(raw)); err != nil {
-			log.Printf("[Jobs] Failed to save segments for job %s: %v", id, err)
-			primitives.JSendError(c, "failed to save segments", http.StatusInternalServerError, nil)
-			return
-		}
-		primitives.JSendSuccess(c, gin.H{"segments": segments})
+		primitives.JSendSuccess(c, gin.H{"segments": saved})
 	})
 
 	// Re-render republishes a fresh VFX Job with the edited segments plus
@@ -205,80 +141,17 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 	// rendering to done. The Output overwrites outputs/<id> in place.
 	r.POST("/jobs/:id/rerender", func(c *gin.Context) {
 		id := c.Param("id")
-		process, err := jobs.Get(id)
+		fresh, err := manager.Rerender(id)
 		if err != nil {
 			respondWithError(c, id, err)
 			return
 		}
-		if process.Stage != job.StageDone {
-			primitives.JSendFail(c, gin.H{"id": fmt.Sprintf("job %s is not re-renderable in stage %s", id, process.Stage)}, http.StatusConflict)
-			return
-		}
-		stored, err := jobs.Segments(id)
-		if err != nil {
-			log.Printf("[Jobs] Failed to read segments for job %s: %v", id, err)
-			primitives.JSendError(c, "failed to read segments", http.StatusInternalServerError, nil)
-			return
-		}
-		var segments []transcriber.Segment
-		if len(stored) > 0 {
-			if err := json.Unmarshal([]byte(stored), &segments); err != nil {
-				log.Printf("[Jobs] Stored segments for job %s do not decode: %v", id, err)
-				primitives.JSendError(c, "stored segments are corrupt", http.StatusInternalServerError, nil)
-				return
-			}
-		}
-		rawSpec, err := jobs.EditSpec(id)
-		if err != nil {
-			log.Printf("[Jobs] Failed to read edit spec for job %s: %v", id, err)
-			primitives.JSendError(c, "failed to read edit spec", http.StatusInternalServerError, nil)
-			return
-		}
-		spec, err := editspec.Parse(rawSpec)
-		if err != nil {
-			log.Printf("[Jobs] Stored edit spec for job %s is invalid: %v", id, err)
-			primitives.JSendError(c, "stored edit spec is invalid", http.StatusInternalServerError, nil)
-			return
-		}
-		// Reopen first: a publish without a stage move would strand the
-		// render with the process still done, and MarkDone would then
-		// refuse the completion. A publish failure after reopen marks the
-		// job failed with its reason, never stranded.
-		reopened, err := writer.Reopen(id)
-		if err != nil {
-			log.Printf("[Jobs] Failed to reopen job %s: %v", id, err)
-			primitives.JSendError(c, "failed to reopen job", http.StatusInternalServerError, nil)
-			return
-		}
-		if !reopened {
-			primitives.JSendFail(c, gin.H{"id": fmt.Sprintf("job %s is not re-renderable in stage %s", id, process.Stage)}, http.StatusConflict)
-			return
-		}
-		rerender := vfxjob.Job{
-			UploadID:  id,
-			ObjectKey: config.ObjectPrefix + id,
-			Segments:  segments,
-			EditSpec:  spec,
-		}
-		if err := publisher.Publish(rerender); err != nil {
-			log.Printf("[Jobs] Failed to publish re-render for job %s: %v", id, err)
-			if _, markErr := writer.MarkFailed(id, fmt.Sprintf("re-render publish failed: %v", err)); markErr != nil {
-				log.Printf("[Jobs] Failed to fail job %s after publish error: %v", id, markErr)
-			}
-			primitives.JSendError(c, "failed to publish re-render", http.StatusInternalServerError, nil)
-			return
-		}
-		fresh, err := jobs.Get(id)
-		if err != nil {
-			log.Printf("[Jobs] Failed to read reopened job %s: %v", id, err)
-			primitives.JSendError(c, "failed to read reopened job", http.StatusInternalServerError, nil)
-			return
-		}
 		primitives.JSendSuccess(c, newProcessResponse(fresh))
 	})
+
 	r.GET("/jobs/:id/download", func(c *gin.Context) {
 		id := c.Param("id")
-		process, err := jobs.Get(id)
+		process, err := manager.Get(id)
 		if err != nil {
 			respondWithError(c, id, err)
 			return
@@ -310,11 +183,11 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 
 	// Deletion is immediate and best-effort (ADR-0004): the row goes first so
 	// the process can never reappear, then the Upload and Output objects go
-	// best-effort — an object that fails to vanish is logged, not retried; the
-	// UI outcome never hangs on storage errors.
+	// best-effort via job.Store.Delete — an object that fails to vanish is
+	// logged, not retried; the UI outcome never hangs on storage errors.
 	r.DELETE("/jobs/:id", func(c *gin.Context) {
 		id := c.Param("id")
-		deleted, err := deleter.Delete(id)
+		deleted, err := manager.Delete(id)
 		if err != nil {
 			log.Printf("[Jobs] Failed to delete job %s: %v", id, err)
 			primitives.JSendError(c, "failed to delete job", http.StatusInternalServerError, nil)
@@ -324,20 +197,27 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 			primitives.JSendFail(c, gin.H{"id": fmt.Sprintf("no job with id %q", id)}, http.StatusNotFound)
 			return
 		}
-
-		for _, prefix := range []string{config.ObjectPrefix + id, config.OutputPrefix + id} {
-			if err := cleaner.Delete(c.Request.Context(), prefix); err != nil {
-				log.Printf("[Jobs] Failed to clean objects under %s for deleted job %s: %v", prefix, id, err)
-			}
-		}
 		c.Status(http.StatusNoContent)
 	})
 }
 
-
 func respondWithError(c *gin.Context, id string, err error) {
 	if errors.Is(err, job.ErrNotFound) {
 		primitives.JSendFail(c, gin.H{"id": fmt.Sprintf("no job with id %q", id)}, http.StatusNotFound)
+		return
+	}
+	if errors.Is(err, job.ErrStageConflict) {
+		var sc *job.StageConflictError
+		if errors.As(err, &sc) {
+			primitives.JSendFail(c, gin.H{"id": sc.Error()}, http.StatusConflict)
+		} else {
+			primitives.JSendFail(c, gin.H{"id": err.Error()}, http.StatusConflict)
+		}
+		return
+	}
+	var valErr *transcriber.ValidationError
+	if errors.As(err, &valErr) {
+		primitives.JSendFail(c, gin.H{"segments": valErr.Error()}, http.StatusBadRequest)
 		return
 	}
 	log.Printf("[Jobs] Failed to read job %s: %v", id, err)

--- a/server/internal/handler/jobs.go
+++ b/server/internal/handler/jobs.go
@@ -206,13 +206,9 @@ func respondWithError(c *gin.Context, id string, err error) {
 		primitives.JSendFail(c, gin.H{"id": fmt.Sprintf("no job with id %q", id)}, http.StatusNotFound)
 		return
 	}
-	if errors.Is(err, job.ErrStageConflict) {
-		var sc *job.StageConflictError
-		if errors.As(err, &sc) {
-			primitives.JSendFail(c, gin.H{"id": sc.Error()}, http.StatusConflict)
-		} else {
-			primitives.JSendFail(c, gin.H{"id": err.Error()}, http.StatusConflict)
-		}
+	var sc *job.StageConflictError
+	if errors.As(err, &sc) {
+		primitives.JSendFail(c, gin.H{"id": sc.Error()}, http.StatusConflict)
 		return
 	}
 	var valErr *transcriber.ValidationError
@@ -220,8 +216,8 @@ func respondWithError(c *gin.Context, id string, err error) {
 		primitives.JSendFail(c, gin.H{"segments": valErr.Error()}, http.StatusBadRequest)
 		return
 	}
-	log.Printf("[Jobs] Failed to read job %s: %v", id, err)
-	primitives.JSendError(c, "failed to read job", http.StatusInternalServerError, nil)
+	log.Printf("[Jobs] Unexpected error for job %s: %v", id, err)
+	primitives.JSendError(c, "internal server error", http.StatusInternalServerError, nil)
 }
 
 // downloadFilename derives a friendly attachment name from the original

--- a/server/internal/handler/jobs.go
+++ b/server/internal/handler/jobs.go
@@ -40,7 +40,7 @@ type JobDeleter interface {
 // Process for re-render, and fails it when the re-render never left;
 // implemented by the job store.
 type JobWriter interface {
-	SaveSegments(id, segmentsJSON string) error
+	SaveOriginalSegments(id, segmentsJSON string) error
 	Reopen(id string) (bool, error)
 	MarkFailed(id, reason string) (bool, error)
 }
@@ -192,7 +192,7 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 			primitives.JSendError(c, "failed to save segments", http.StatusInternalServerError, nil)
 			return
 		}
-		if err := writer.SaveSegments(id, string(raw)); err != nil {
+		if err := writer.SaveOriginalSegments(id, string(raw)); err != nil {
 			log.Printf("[Jobs] Failed to save segments for job %s: %v", id, err)
 			primitives.JSendError(c, "failed to save segments", http.StatusInternalServerError, nil)
 			return

--- a/server/internal/handler/jobs.go
+++ b/server/internal/handler/jobs.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"net/http"
 	"path"
 	"strings"
@@ -165,7 +164,7 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 			primitives.JSendFail(c, gin.H{"segments": "segments must decode as timed text"}, http.StatusBadRequest)
 			return
 		}
-		if err := validateSegmentTiming(segments); err != nil {
+		if err := transcriber.ValidateSegmentTiming(segments); err != nil {
 			primitives.JSendFail(c, gin.H{"segments": err.Error()}, http.StatusBadRequest)
 			return
 		}
@@ -180,7 +179,7 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 						break
 					}
 					if segments[i].Start != original[i].Start || segments[i].End != original[i].End {
-						segments[i].Words = rescaleWords(original[i], segments[i])
+						segments[i].Words = transcriber.RescaleWords(original[i], segments[i])
 					} else {
 						segments[i].Words = original[i].Words
 					}
@@ -335,52 +334,6 @@ func RegisterJobs(r *gin.Engine, jobs JobReader, writer JobWriter, deleter JobDe
 	})
 }
 
-// validateSegmentTiming rejects edited segments the render cannot use:
-// non-finite times, negative starts, ends at or before their start, and
-// segments that start before the previous one ends.
-func validateSegmentTiming(segments []transcriber.Segment) error {
-	for i, seg := range segments {
-		if !finiteTime(seg.Start) || !finiteTime(seg.End) {
-			return fmt.Errorf("segment %d must carry finite start and end times", i+1)
-		}
-		if seg.Start < 0 {
-			return fmt.Errorf("segment %d start must not be negative", i+1)
-		}
-		if seg.End <= seg.Start {
-			return fmt.Errorf("segment %d end must be after its start", i+1)
-		}
-		if i > 0 && seg.Start < segments[i-1].End {
-			return fmt.Errorf("segment %d must not start before segment %d ends", i+1, i)
-		}
-	}
-	return nil
-}
-
-// rescaleWords keeps a segment's whisper-original word timings at their
-// relative offsets, scaled into the edited window. Word timings are never
-// re-derived from scratch; a degenerate original window leaves words alone.
-func rescaleWords(original, edited transcriber.Segment) []transcriber.Word {
-	if len(original.Words) == 0 {
-		return original.Words
-	}
-	span := original.End - original.Start
-	if span <= 0 {
-		return original.Words
-	}
-	words := make([]transcriber.Word, len(original.Words))
-	for i, w := range original.Words {
-		words[i] = transcriber.Word{
-			Text:  w.Text,
-			Start: edited.Start + (w.Start-original.Start)/span*(edited.End-edited.Start),
-			End:   edited.Start + (w.End-original.Start)/span*(edited.End-edited.Start),
-		}
-	}
-	return words
-}
-
-func finiteTime(value float64) bool {
-	return !math.IsNaN(value) && !math.IsInf(value, 0)
-}
 
 func respondWithError(c *gin.Context, id string, err error) {
 	if errors.Is(err, job.ErrNotFound) {

--- a/server/internal/handler/jobs_rerender_test.go
+++ b/server/internal/handler/jobs_rerender_test.go
@@ -41,13 +41,13 @@ func newRerenderRouter(t *testing.T) (*gin.Engine, *job.Store, *fakeRerenderPubl
 	}
 	t.Cleanup(func() { database.Close() })
 
-	store, err := job.NewStore(database)
-	if err != nil {
-		t.Fatalf("create job store: %v", err)
-	}
 	pub := &fakeRerenderPublisher{}
 	outputs := &fakeOutputs{body: "video bytes"}
 	cleaner := &fakeCleaner{}
+	store, err := job.NewStore(database, pub, cleaner)
+	if err != nil {
+		t.Fatalf("create job store: %v", err)
+	}
 	router := gin.New()
 	RegisterJobs(router, store, store, store, pub, outputs, cleaner)
 	return router, store, pub
@@ -76,7 +76,7 @@ func createDoneJob(t *testing.T, store *job.Store, id string) {
 		t.Fatalf("create: %v", err)
 	}
 	const stored = `[{"start":1.5,"end":2.5,"text":"hello","words":[{"text":"hello","start":1.6,"end":2.4}]}]`
-	if err := store.SaveSegments(id, stored); err != nil {
+	if err := store.SaveOriginalSegments(id, stored); err != nil {
 		t.Fatalf("save segments: %v", err)
 	}
 	if recorded, err := store.MarkRendering(id); err != nil || !recorded {

--- a/server/internal/handler/jobs_rerender_test.go
+++ b/server/internal/handler/jobs_rerender_test.go
@@ -1,37 +1,24 @@
 package handler
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/rubichandrap/subvision/server/internal/db"
 	"github.com/rubichandrap/subvision/server/internal/job"
 	"github.com/rubichandrap/subvision/server/internal/vfxjob"
 )
 
-type fakeRerenderPublisher struct {
-	jobs []vfxjob.Job
-	err  error
-}
+// fakeRerenderPublisher is a no-op VFX publisher that always succeeds,
+// satisfying job.VfxPublisher.
+type fakeRerenderPublisher struct{}
 
-func (f *fakeRerenderPublisher) Publish(job vfxjob.Job) error {
-	if f.err != nil {
-		return f.err
-	}
-	f.jobs = append(f.jobs, job)
-	return nil
-}
+func (f *fakeRerenderPublisher) Publish(_ vfxjob.Job) error { return nil }
 
-var errBrokerDown = errors.New("broker down")
-
-func newRerenderRouter(t *testing.T) (*gin.Engine, *job.Store, *fakeRerenderPublisher) {
+// newRerenderRouter builds a router backed by a real in-memory job.Store for
+// smoke testing the rerender and segment-save routes.
+func newRerenderRouter(t *testing.T) (*gin.Engine, *job.Store) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
@@ -43,235 +30,79 @@ func newRerenderRouter(t *testing.T) (*gin.Engine, *job.Store, *fakeRerenderPubl
 
 	pub := &fakeRerenderPublisher{}
 	outputs := &fakeOutputs{body: "video bytes"}
-	cleaner := &fakeCleaner{}
-	store, err := job.NewStore(database, pub, cleaner)
+	store, err := job.NewStore(database, pub, &fakeCleaner{})
 	if err != nil {
 		t.Fatalf("create job store: %v", err)
 	}
 	router := gin.New()
-	RegisterJobs(router, store, store, store, pub, outputs, cleaner)
-	return router, store, pub
+	RegisterJobs(router, store, outputs)
+	return router, store
 }
 
-func doPut(t *testing.T, router *gin.Engine, path, body string) *httptest.ResponseRecorder {
-	t.Helper()
-	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rec := httptest.NewRecorder()
-	router.ServeHTTP(rec, req)
-	return rec
-}
-
-func doPost(t *testing.T, router *gin.Engine, path string) *httptest.ResponseRecorder {
-	t.Helper()
-	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(nil))
-	rec := httptest.NewRecorder()
-	router.ServeHTTP(rec, req)
-	return rec
-}
-
-func createDoneJob(t *testing.T, store *job.Store, id string) {
-	t.Helper()
-	if err := store.Create(id, "clip.mp4"); err != nil {
-		t.Fatalf("create: %v", err)
-	}
-	const stored = `[{"start":1.5,"end":2.5,"text":"hello","words":[{"text":"hello","start":1.6,"end":2.4}]}]`
-	if err := store.SaveOriginalSegments(id, stored); err != nil {
-		t.Fatalf("save segments: %v", err)
-	}
-	if recorded, err := store.MarkRendering(id); err != nil || !recorded {
-		t.Fatalf("mark rendering: recorded=%v err=%v", recorded, err)
-	}
-	if recorded, err := store.MarkDone(id, "outputs/"+id); err != nil || !recorded {
-		t.Fatalf("mark done: recorded=%v err=%v", recorded, err)
-	}
-}
-
-func TestSaveSegmentsPersistsEdits(t *testing.T) {
-	router, store, _ := newRerenderRouter(t)
-	createDoneJob(t, store, "u1")
-
-	const edited = `{"segments":[{"start":1.0,"end":2.0,"text":"fixed","words":[]}]}`
-	rec := doPut(t, router, "/jobs/u1/segments", edited)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("PUT /jobs/u1/segments = %d: %s", rec.Code, rec.Body)
-	}
-
-	got, err := store.Segments("u1")
-	if err != nil {
-		t.Fatalf("read segments: %v", err)
-	}
-	var decoded []map[string]any
-	if err := json.Unmarshal([]byte(got), &decoded); err != nil {
-		t.Fatalf("stored segments not JSON: %v", err)
-	}
-	if len(decoded) != 1 || decoded[0]["text"] != "fixed" {
-		t.Errorf("stored segments = %s, want the edited text", got)
-	}
-}
-
-func TestSaveSegmentsRescalesWordOffsets(t *testing.T) {
-	router, store, _ := newRerenderRouter(t)
-	createDoneJob(t, store, "u1")
-
-	// Original window 1.5-2.5 with word 1.6-2.4; edited window 1.0-3.0
-	// must keep the word at its relative offset, scaled: 1.2-2.8.
-	const edited = `{"segments":[{"start":1.0,"end":3.0,"text":"hello","words":[{"text":"hello","start":9.9,"end":9.9}]}]}`
-	if rec := doPut(t, router, "/jobs/u1/segments", edited); rec.Code != http.StatusOK {
-		t.Fatalf("PUT /jobs/u1/segments = %d: %s", rec.Code, rec.Body)
-	}
-	got, err := store.Segments("u1")
-	if err != nil {
-		t.Fatalf("read segments: %v", err)
-	}
-	var decoded []struct {
-		Words []struct {
-			Start float64 `json:"start"`
-			End   float64 `json:"end"`
-		} `json:"words"`
-	}
-	if err := json.Unmarshal([]byte(got), &decoded); err != nil {
-		t.Fatalf("stored segments not JSON: %v", err)
-	}
-	if len(decoded) != 1 || len(decoded[0].Words) != 1 {
-		t.Fatalf("stored segments = %s, want one segment with one word", got)
-	}
-	w := decoded[0].Words[0]
-	const wantStart, wantEnd = 1.2, 2.8
-	if diff := w.Start - wantStart; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("word start = %v, want %v (relative offset scaled)", w.Start, wantStart)
-	}
-	if diff := w.End - wantEnd; diff > 1e-9 || diff < -1e-9 {
-		t.Errorf("word end = %v, want %v (relative offset scaled)", w.End, wantEnd)
-	}
-}
-
-func TestSaveSegmentsRejectsBadTiming(t *testing.T) {
-	router, store, _ := newRerenderRouter(t)
-	createDoneJob(t, store, "u1")
-
-	for name, body := range map[string]string{
-		"negative start":   `{"segments":[{"start":-1,"end":2,"text":"x","words":[]}]}`,
-		"end before start": `{"segments":[{"start":2,"end":1,"text":"x","words":[]}]}`,
-		"unordered":        `{"segments":[{"start":0,"end":5,"text":"a","words":[]},{"start":1,"end":2,"text":"b","words":[]}]}`,
-		"non-finite":       `{"segments":[{"start":"soon","end":2,"text":"x","words":[]}]}`,
-		"malformed json":   `{"segments":[}`,
-	} {
-		rec := doPut(t, router, "/jobs/u1/segments", body)
-		if rec.Code != http.StatusBadRequest {
-			t.Errorf("%s: PUT = %d, want 400 (%s)", name, rec.Code, rec.Body)
-		}
-	}
-}
-
-func TestSaveSegmentsUnknownJobReturns404(t *testing.T) {
-	router, _, _ := newRerenderRouter(t)
-
-	rec := doPut(t, router, "/jobs/missing/segments", `{"segments":[]}`)
+// TestRerenderRouteIsRegistered verifies the POST /jobs/:id/rerender route
+// exists and returns 404 (not 405 Method Not Allowed) for unknown jobs,
+// confirming the route is wired.
+func TestRerenderRouteIsRegistered(t *testing.T) {
+	router, _ := newRerenderRouter(t)
+	rec := doPost(t, router, "/jobs/missing/rerender")
 	if rec.Code != http.StatusNotFound {
-		t.Errorf("PUT /jobs/missing/segments = %d, want 404", rec.Code)
+		t.Errorf("POST /jobs/missing/rerender = %d, want 404 (route must be registered)", rec.Code)
 	}
 }
 
-func TestRerenderPublishesJobWithEditedSegments(t *testing.T) {
-	router, store, pub := newRerenderRouter(t)
-	createDoneJob(t, store, "u1")
-
-	const spec = `{"trim":{"start":2,"end":9},"frame":{"preset":"9:16","ratio":0.5625,"zoom":1,"panX":0,"panY":0},"animation":"karaoke"}`
-	if err := store.SaveEditSpec("u1", spec); err != nil {
-		t.Fatalf("save edit spec: %v", err)
-	}
-	const edited = `{"segments":[{"start":1.0,"end":2.0,"text":"fixed","words":[]}]}`
-	if rec := doPut(t, router, "/jobs/u1/segments", edited); rec.Code != http.StatusOK {
-		t.Fatalf("PUT segments = %d: %s", rec.Code, rec.Body)
-	}
-
-	rec := doPost(t, router, "/jobs/u1/rerender")
-	if rec.Code != http.StatusOK {
-		t.Fatalf("POST /jobs/u1/rerender = %d: %s", rec.Code, rec.Body)
-	}
-
-	got, err := store.Get("u1")
-	if err != nil {
-		t.Fatalf("get: %v", err)
-	}
-	if got.Stage != job.StageRendering {
-		t.Errorf("stage = %q, want rendering", got.Stage)
-	}
-
-	if len(pub.jobs) != 1 {
-		t.Fatalf("expected one published vfx job, got %d", len(pub.jobs))
-	}
-	rerender := pub.jobs[0]
-	if rerender.UploadID != "u1" {
-		t.Errorf("UploadID = %q, want u1", rerender.UploadID)
-	}
-	if rerender.ObjectKey != "uploads/u1" {
-		t.Errorf("ObjectKey = %q, want uploads/u1", rerender.ObjectKey)
-	}
-	if len(rerender.Segments) != 1 || rerender.Segments[0].Text != "fixed" {
-		t.Errorf("rerender must carry edited segments: %+v", rerender.Segments)
-	}
-	if rerender.EditSpec == nil || rerender.EditSpec.Animation != "karaoke" {
-		t.Errorf("rerender must carry the original edit spec: %+v", rerender.EditSpec)
+// TestSaveSegmentsRouteIsRegistered verifies the PUT /jobs/:id/segments route
+// exists and returns 400 for a bad body (not 405), confirming the route is wired.
+func TestSaveSegmentsRouteIsRegistered(t *testing.T) {
+	router, _ := newRerenderRouter(t)
+	rec := doPut(t, router, "/jobs/missing/segments", `{}`)
+	// {} has no segments field → 400 bad request before the store is hit
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("PUT /jobs/missing/segments = %d, want 400 (route must be registered)", rec.Code)
 	}
 }
 
-func TestRerenderWithoutEditsRepublishesStoredSegments(t *testing.T) {
-	router, store, pub := newRerenderRouter(t)
-	createDoneJob(t, store, "u1")
-
-	if rec := doPost(t, router, "/jobs/u1/rerender"); rec.Code != http.StatusOK {
-		t.Fatalf("POST /jobs/u1/rerender = %d: %s", rec.Code, rec.Body)
-	}
-	if len(pub.jobs) != 1 {
-		t.Fatalf("expected one published vfx job, got %d", len(pub.jobs))
-	}
-	rerender := pub.jobs[0]
-	if len(rerender.Segments) != 1 || rerender.Segments[0].Text != "hello" {
-		t.Errorf("unedited re-render must carry the stored segments: %+v", rerender.Segments)
-	}
-	if rerender.EditSpec != nil {
-		t.Errorf("unedited re-render without a spec must carry nil spec: %+v", rerender.EditSpec)
-	}
-	if got, err := store.Get("u1"); err != nil || got.Stage != job.StageRendering {
-		t.Errorf("stage must be rendering after re-render (got %+v, err %v)", got, err)
-	}
-}
-
-func TestRerenderPublishFailureFailsJob(t *testing.T) {
-	router, store, pub := newRerenderRouter(t)
-	createDoneJob(t, store, "u1")
-	pub.err = errBrokerDown
-
-	if rec := doPost(t, router, "/jobs/u1/rerender"); rec.Code != http.StatusInternalServerError {
-		t.Fatalf("POST /jobs/u1/rerender = %d, want 500 (%s)", rec.Code, rec.Body)
-	}
-	got, err := store.Get("u1")
-	if err != nil {
-		t.Fatalf("get: %v", err)
-	}
-	if got.Stage != job.StageFailed {
-		t.Errorf("stage = %q, want failed (never stranded in rendering)", got.Stage)
-	}
-	if got.Reason == "" {
-		t.Error("failed re-render must surface its reason")
-	}
-}
-
-func TestRerenderRefusesNonDone(t *testing.T) {
-	router, store, pub := newRerenderRouter(t)
+// TestRerenderReturns409ForNonDoneJob verifies the handler maps
+// ErrStageConflict → 409 Conflict.
+func TestRerenderReturns409ForNonDoneJob(t *testing.T) {
+	router, store := newRerenderRouter(t)
 	if err := store.Create("u1", "clip.mp4"); err != nil {
 		t.Fatalf("create: %v", err)
 	}
+	rec := doPost(t, router, "/jobs/u1/rerender")
+	if rec.Code != http.StatusConflict {
+		t.Errorf("POST /jobs/u1/rerender (uploaded stage) = %d, want 409", rec.Code)
+	}
+}
 
-	if rec := doPost(t, router, "/jobs/u1/rerender"); rec.Code != http.StatusConflict {
-		t.Errorf("POST rerender of in-flight job = %d, want 409", rec.Code)
+// TestSaveSegmentsReturns409ForUneditableStage verifies the handler maps
+// ErrStageConflict → 409 when segments are saved on an in-flight (non-editable) job.
+func TestSaveSegmentsReturns409ForUneditableStage(t *testing.T) {
+	router, store := newRerenderRouter(t)
+	if err := store.Create("u1", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
 	}
-	if rec := doPost(t, router, "/jobs/missing/rerender"); rec.Code != http.StatusNotFound {
-		t.Errorf("POST rerender of unknown job = %d, want 404", rec.Code)
+	// uploaded stage is not editable
+	const body = `{"segments":[{"start":1.0,"end":2.0,"text":"x","words":[]}]}`
+	rec := doPut(t, router, "/jobs/u1/segments", body)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("PUT /jobs/u1/segments (uploaded stage) = %d, want 409", rec.Code)
 	}
-	if len(pub.jobs) != 0 {
-		t.Errorf("refused re-render must not publish, got %d jobs", len(pub.jobs))
+}
+
+// TestSaveSegmentsReturns400ForBadTiming verifies the handler maps
+// transcriber.ValidationError → 400 Bad Request.
+func TestSaveSegmentsReturns400ForBadTiming(t *testing.T) {
+	router, store := newRerenderRouter(t)
+	if err := store.Create("u1", "clip.mp4"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := store.MarkRendering("u1"); err != nil {
+		t.Fatalf("mark rendering: %v", err)
+	}
+	// negative start → ValidationError
+	const body = `{"segments":[{"start":-1,"end":2,"text":"x","words":[]}]}`
+	rec := doPut(t, router, "/jobs/u1/segments", body)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("PUT /jobs/u1/segments (bad timing) = %d, want 400", rec.Code)
 	}
 }

--- a/server/internal/handler/jobs_test.go
+++ b/server/internal/handler/jobs_test.go
@@ -63,7 +63,7 @@ func newJobsRouter(t *testing.T) (*gin.Engine, *job.Store, *fakeOutputs, *fakeCl
 		t.Fatalf("create job store: %v", err)
 	}
 	router := gin.New()
-	RegisterJobs(router, store, store, store, nilPublisher{}, outputs, cleaner)
+	RegisterJobs(router, store, outputs)
 	return router, store, outputs, cleaner
 }
 
@@ -78,6 +78,23 @@ func doGet(t *testing.T, router *gin.Engine, path string) *httptest.ResponseReco
 func doDelete(t *testing.T, router *gin.Engine, path string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodDelete, path, nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func doPut(t *testing.T, router *gin.Engine, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+func doPost(t *testing.T, router *gin.Engine, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 	return rec

--- a/server/internal/handler/jobs_test.go
+++ b/server/internal/handler/jobs_test.go
@@ -56,12 +56,12 @@ func newJobsRouter(t *testing.T) (*gin.Engine, *job.Store, *fakeOutputs, *fakeCl
 	}
 	t.Cleanup(func() { database.Close() })
 
-	store, err := job.NewStore(database)
+	outputs := &fakeOutputs{body: "video bytes"}
+	cleaner := &fakeCleaner{}
+	store, err := job.NewStore(database, nilPublisher{}, cleaner)
 	if err != nil {
 		t.Fatalf("create job store: %v", err)
 	}
-	outputs := &fakeOutputs{body: "video bytes"}
-	cleaner := &fakeCleaner{}
 	router := gin.New()
 	RegisterJobs(router, store, store, store, nilPublisher{}, outputs, cleaner)
 	return router, store, outputs, cleaner
@@ -180,7 +180,7 @@ func TestSegmentsEndpointServesStoredTranscript(t *testing.T) {
 	}
 
 	const stored = `[{"start":1.5,"end":2.5,"text":"hello","words":[{"text":"hello","start":1.6,"end":2.4}]}]`
-	if err := store.SaveSegments("u1", stored); err != nil {
+	if err := store.SaveOriginalSegments("u1", stored); err != nil {
 		t.Fatalf("save segments: %v", err)
 	}
 	if recorded, err := store.MarkRendering("u1"); err != nil || !recorded {

--- a/server/internal/job/job.go
+++ b/server/internal/job/job.go
@@ -2,14 +2,20 @@
 // moving from uploaded through transcribing and rendering to done or failed.
 // The client reads it through the status API; nothing else invents it.
 package job
-
 import (
+	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"time"
-)
 
+	"github.com/rubichandrap/subvision/server/internal/config"
+	"github.com/rubichandrap/subvision/server/internal/editspec"
+	"github.com/rubichandrap/subvision/server/internal/transcriber"
+	"github.com/rubichandrap/subvision/server/internal/vfxjob"
+)
 type Stage string
 
 const (
@@ -35,6 +41,34 @@ func (s Stage) valid() bool {
 
 // ErrNotFound is returned by Get when no process carries the requested id.
 var ErrNotFound = errors.New("job not found")
+// StageConflictError is returned when an operation is invalid for the process's current stage.
+type StageConflictError struct {
+	ID    string
+	Stage Stage
+	Op    string
+}
+
+func (e *StageConflictError) Error() string {
+	return fmt.Sprintf("job %s is not %s in stage %s", e.ID, e.Op, e.Stage)
+}
+
+// ErrStageConflict is a sentinel error that matches any StageConflictError via errors.Is.
+var ErrStageConflict = errors.New("stage conflict")
+
+func (e *StageConflictError) Is(target error) bool {
+	return target == ErrStageConflict
+}
+
+// VfxPublisher publishes VFX Jobs; implemented by the rabbitmq publisher and faked in tests.
+type VfxPublisher interface {
+	Publish(job vfxjob.Job) error
+}
+
+// ObjectCleaner removes stored objects under a key prefix best-effort; implemented by the storage client and faked in tests.
+type ObjectCleaner interface {
+	Delete(ctx context.Context, prefix string) error
+}
+
 
 type Process struct {
 	ID        string
@@ -57,19 +91,21 @@ type Tracker interface {
 	// Reopen moves a done job back to rendering for a re-render, bypassing
 	// the terminal-stage guard that mark enforces for the normal pipeline.
 	Reopen(uploadID string) (bool, error)
-	// SaveSegments persists the whisper-original Transcription Segments for
+	// SaveOriginalSegments persists the whisper-original Transcription Segments for
 	// an upload as JSON, so they outlive the queue message.
-	SaveSegments(uploadID, segmentsJSON string) error
+	SaveOriginalSegments(uploadID, segmentsJSON string) error
 	// SaveEditSpec persists the upload's original Edit Spec as JSON, so a
 	// re-render reuses it. Empty when the upload carried no spec.
 	SaveEditSpec(uploadID, specJSON string) error
 }
 
 type Store struct {
-	db *sql.DB
+	db        *sql.DB
+	publisher VfxPublisher
+	cleaner   ObjectCleaner
 }
 
-func NewStore(db *sql.DB) (*Store, error) {
+func NewStore(db *sql.DB, publisher VfxPublisher, cleaner ObjectCleaner) (*Store, error) {
 	_, err := db.Exec(`
 		CREATE TABLE IF NOT EXISTS jobs (
 			id         TEXT PRIMARY KEY,
@@ -104,7 +140,11 @@ func NewStore(db *sql.DB) (*Store, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create job_edit_specs table: %w", err)
 	}
-	return &Store{db: db}, nil
+	return &Store{
+		db:        db,
+		publisher: publisher,
+		cleaner:   cleaner,
+	}, nil
 }
 
 // Create records a new process in the uploaded stage, called when the upload
@@ -201,13 +241,98 @@ func (s *Store) Delete(id string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to delete job %s: %w", id, err)
 	}
-	return affected > 0, nil
+	if affected == 0 {
+		return false, nil
+	}
+
+	if s.cleaner != nil {
+		for _, prefix := range []string{config.ObjectPrefix + id, config.OutputPrefix + id} {
+			if err := s.cleaner.Delete(context.Background(), prefix); err != nil {
+				log.Printf("[Job] Failed to clean objects under %s for deleted job %s: %v", prefix, id, err)
+			}
+		}
+	}
+	return true, nil
 }
 
-// SaveSegments stores the whisper-original Transcription Segments for an
+// Rerender verifies the Process is in done stage, loads stored segments and Edit Spec,
+// transitions stage to rendering, and publishes a fresh vfxjob.Job. If re-render publish
+// fails, it transitions the process to failed with the error reason and returns an error.
+func (s *Store) Rerender(id string) (*Process, error) {
+	proc, err := s.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	if proc.Stage != StageDone {
+		return nil, &StageConflictError{
+			ID:    id,
+			Stage: proc.Stage,
+			Op:    "re-renderable",
+		}
+	}
+
+	stored, err := s.Segments(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stored segments for job %s: %w", id, err)
+	}
+	var segments []transcriber.Segment
+	if len(stored) > 0 {
+		if err := json.Unmarshal([]byte(stored), &segments); err != nil {
+			return nil, fmt.Errorf("stored segments for job %s are corrupt: %w", id, err)
+		}
+	}
+
+	rawSpec, err := s.EditSpec(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read edit spec for job %s: %w", id, err)
+	}
+	spec, err := editspec.Parse(rawSpec)
+	if err != nil {
+		return nil, fmt.Errorf("stored edit spec for job %s is invalid: %w", id, err)
+	}
+
+	if s.publisher == nil {
+		return nil, errors.New("vfx publisher not configured")
+	}
+
+	reopened, err := s.Reopen(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reopen job %s: %w", id, err)
+	}
+	if !reopened {
+		return nil, &StageConflictError{
+			ID:    id,
+			Stage: proc.Stage,
+			Op:    "re-renderable",
+		}
+	}
+
+	job := vfxjob.Job{
+		UploadID:  id,
+		ObjectKey: config.ObjectPrefix + id,
+		Segments:  segments,
+		EditSpec:  spec,
+	}
+
+	if err := s.publisher.Publish(job); err != nil {
+		failReason := fmt.Sprintf("re-render publish failed: %v", err)
+		if _, markErr := s.MarkFailed(id, failReason); markErr != nil {
+			log.Printf("[Job] Failed to mark job %s failed after publish error: %v", id, markErr)
+		}
+		return nil, fmt.Errorf("failed to publish re-render: %w", err)
+	}
+
+	fresh, err := s.Get(id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read reopened job %s: %w", id, err)
+	}
+	return fresh, nil
+}
+
+// SaveOriginalSegments stores the whisper-original Transcription Segments for an
 // upload as JSON, replacing any earlier copy. It outlives the queue message
 // so the transcript stays readable after the job reaches done.
-func (s *Store) SaveSegments(uploadID, segmentsJSON string) error {
+func (s *Store) SaveOriginalSegments(uploadID, segmentsJSON string) error {
 	_, err := s.db.Exec(
 		`INSERT INTO job_segments (job_id, segments, updated_at) VALUES (?, ?, ?)
 		 ON CONFLICT(job_id) DO UPDATE SET segments = excluded.segments, updated_at = excluded.updated_at`,
@@ -218,6 +343,53 @@ func (s *Store) SaveSegments(uploadID, segmentsJSON string) error {
 	}
 	return nil
 }
+
+// SaveSegments enforces that the Process is in rendering or done stage, validates timings,
+// rescales words against whisper originals, and saves to job_segments.
+func (s *Store) SaveSegments(id string, segments []transcriber.Segment) ([]transcriber.Segment, error) {
+	proc, err := s.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	if proc.Stage != StageRendering && proc.Stage != StageDone {
+		return nil, &StageConflictError{
+			ID:    id,
+			Stage: proc.Stage,
+			Op:    "editable",
+		}
+	}
+	if err := transcriber.ValidateSegmentTiming(segments); err != nil {
+		return nil, err
+	}
+
+	// Rescale word offsets against whisper originals if present
+	if stored, err := s.Segments(id); err == nil && len(stored) > 0 {
+		var original []transcriber.Segment
+		if json.Unmarshal([]byte(stored), &original) == nil {
+			for i := range segments {
+				if i >= len(original) {
+					break
+				}
+				if segments[i].Start != original[i].Start || segments[i].End != original[i].End {
+					segments[i].Words = transcriber.RescaleWords(original[i], segments[i])
+				} else {
+					segments[i].Words = original[i].Words
+				}
+			}
+		}
+	}
+
+	raw, err := json.Marshal(segments)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal segments for job %s: %w", id, err)
+	}
+
+	if err := s.SaveOriginalSegments(id, string(raw)); err != nil {
+		return nil, err
+	}
+	return segments, nil
+}
+
 
 // SaveEditSpec stores the upload's original Edit Spec as raw JSON, so a
 // re-render reuses it. An empty raw means "no edit" and clears any stored

--- a/server/internal/job/job_reopen_test.go
+++ b/server/internal/job/job_reopen_test.go
@@ -12,7 +12,7 @@ func TestReopenMovesDoneToRendering(t *testing.T) {
 		t.Fatalf("open sqlite: %v", err)
 	}
 	t.Cleanup(func() { handle.Close() })
-	store, err := NewStore(handle)
+	store, err := NewStore(handle, nil, nil)
 	if err != nil {
 		t.Fatalf("create job store: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestReopenRefusesNonDone(t *testing.T) {
 		t.Fatalf("open sqlite: %v", err)
 	}
 	t.Cleanup(func() { handle.Close() })
-	store, err := NewStore(handle)
+	store, err := NewStore(handle, nil, nil)
 	if err != nil {
 		t.Fatalf("create job store: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestEditSpecRoundTrip(t *testing.T) {
 		t.Fatalf("open sqlite: %v", err)
 	}
 	t.Cleanup(func() { handle.Close() })
-	store, err := NewStore(handle)
+	store, err := NewStore(handle, nil, nil)
 	if err != nil {
 		t.Fatalf("create job store: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestEditSpecEmptyWhenNoneStored(t *testing.T) {
 		t.Fatalf("open sqlite: %v", err)
 	}
 	t.Cleanup(func() { handle.Close() })
-	store, err := NewStore(handle)
+	store, err := NewStore(handle, nil, nil)
 	if err != nil {
 		t.Fatalf("create job store: %v", err)
 	}

--- a/server/internal/job/job_segments_test.go
+++ b/server/internal/job/job_segments_test.go
@@ -13,7 +13,7 @@ func newSegmentsTestStore(t *testing.T) *Store {
 		t.Fatalf("open sqlite: %v", err)
 	}
 	t.Cleanup(func() { handle.Close() })
-	store, err := NewStore(handle)
+	store, err := NewStore(handle, nil, nil)
 	if err != nil {
 		t.Fatalf("create job store: %v", err)
 	}
@@ -28,7 +28,7 @@ func TestSegmentsRoundTrip(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	if err := store.SaveSegments("u1", segmentsFixture); err != nil {
+	if err := store.SaveOriginalSegments("u1", segmentsFixture); err != nil {
 		t.Fatalf("save segments: %v", err)
 	}
 
@@ -73,7 +73,7 @@ func TestDeleteRemovesSegments(t *testing.T) {
 	if err := store.Create("u1", "clip.mp4"); err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	if err := store.SaveSegments("u1", segmentsFixture); err != nil {
+	if err := store.SaveOriginalSegments("u1", segmentsFixture); err != nil {
 		t.Fatalf("save segments: %v", err)
 	}
 

--- a/server/internal/job/store_test.go
+++ b/server/internal/job/store_test.go
@@ -1,0 +1,371 @@
+package job
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rubichandrap/subvision/server/internal/db"
+	"github.com/rubichandrap/subvision/server/internal/transcriber"
+	"github.com/rubichandrap/subvision/server/internal/vfxjob"
+)
+
+type fakePublisher struct {
+	published []vfxjob.Job
+	err       error
+}
+
+func (f *fakePublisher) Publish(job vfxjob.Job) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.published = append(f.published, job)
+	return nil
+}
+
+type fakeCleaner struct {
+	deleted []string
+	err     error
+}
+
+func (f *fakeCleaner) Delete(ctx context.Context, prefix string) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.deleted = append(f.deleted, prefix)
+	return nil
+}
+
+func newTestStoreWithPorts(t *testing.T, pub VfxPublisher, cleaner ObjectCleaner) *Store {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	store, err := NewStore(database, pub, cleaner)
+	if err != nil {
+		t.Fatalf("create job store: %v", err)
+	}
+	return store
+}
+
+func createJobWithStage(t *testing.T, store *Store, id string, stage Stage) {
+	t.Helper()
+	if err := store.Create(id, "video.mp4"); err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	switch stage {
+	case StageUploaded:
+		// already uploaded
+	case StageTranscribing:
+		if _, err := store.MarkTranscribing(id); err != nil {
+			t.Fatalf("mark transcribing: %v", err)
+		}
+	case StageRendering:
+		if _, err := store.MarkRendering(id); err != nil {
+			t.Fatalf("mark rendering: %v", err)
+		}
+	case StageDone:
+		if _, err := store.MarkDone(id, "outputs/"+id); err != nil {
+			t.Fatalf("mark done: %v", err)
+		}
+	case StageFailed:
+		if _, err := store.MarkFailed(id, "pipeline error"); err != nil {
+			t.Fatalf("mark failed: %v", err)
+		}
+	}
+}
+
+func TestSaveSegmentsRejectsUneditableStages(t *testing.T) {
+	uneditableStages := []Stage{StageUploaded, StageTranscribing, StageFailed}
+	for _, stage := range uneditableStages {
+		t.Run(string(stage), func(t *testing.T) {
+			store := newTestStoreWithPorts(t, &fakePublisher{}, &fakeCleaner{})
+			id := "job-" + string(stage)
+			createJobWithStage(t, store, id, stage)
+
+			segments := []transcriber.Segment{
+				{Start: 1.0, End: 2.0, Text: "hello"},
+			}
+			_, err := store.SaveSegments(id, segments)
+			if err == nil {
+				t.Fatalf("expected error saving segments in stage %s, got nil", stage)
+			}
+			var conflictErr *StageConflictError
+			if !errors.As(err, &conflictErr) {
+				t.Fatalf("expected StageConflictError, got %T (%v)", err, err)
+			}
+			if conflictErr.Stage != stage {
+				t.Errorf("conflict error stage = %q, want %q", conflictErr.Stage, stage)
+			}
+			if conflictErr.ID != id {
+				t.Errorf("conflict error id = %q, want %q", conflictErr.ID, id)
+			}
+		})
+	}
+}
+
+func TestSaveSegmentsAllowsRenderingAndDone(t *testing.T) {
+	for _, stage := range []Stage{StageRendering, StageDone} {
+		t.Run(string(stage), func(t *testing.T) {
+			store := newTestStoreWithPorts(t, &fakePublisher{}, &fakeCleaner{})
+			id := "job-" + string(stage)
+			createJobWithStage(t, store, id, stage)
+
+			segments := []transcriber.Segment{
+				{Start: 1.0, End: 2.5, Text: "valid segment"},
+			}
+			saved, err := store.SaveSegments(id, segments)
+			if err != nil {
+				t.Fatalf("unexpected error saving segments in stage %s: %v", stage, err)
+			}
+			if len(saved) != 1 || saved[0].Text != "valid segment" {
+				t.Fatalf("unexpected saved segments: %+v", saved)
+			}
+		})
+	}
+}
+
+func TestSaveSegmentsValidatesTimings(t *testing.T) {
+	store := newTestStoreWithPorts(t, &fakePublisher{}, &fakeCleaner{})
+	id := "job-invalid-timing"
+	createJobWithStage(t, store, id, StageDone)
+
+	// End before Start violates timing invariants
+	segments := []transcriber.Segment{
+		{Start: 2.5, End: 1.0, Text: "backward time"},
+	}
+	_, err := store.SaveSegments(id, segments)
+	if err == nil {
+		t.Fatal("expected validation error for invalid timing, got nil")
+	}
+	var valErr *transcriber.TimingValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("expected TimingValidationError, got %T (%v)", err, err)
+	}
+}
+
+func TestSaveSegmentsRescalesWordsAgainstWhisperOriginals(t *testing.T) {
+	store := newTestStoreWithPorts(t, &fakePublisher{}, &fakeCleaner{})
+	id := "job-rescale"
+	createJobWithStage(t, store, id, StageDone)
+
+	// Store whisper original segment with timed words
+	originalJSON := `[{"start":1.0,"end":2.0,"text":"hello world","words":[{"start":1.1,"end":1.5,"text":"hello"},{"start":1.6,"end":1.9,"text":"world"}]}]`
+	if err := store.SaveOriginalSegments(id, originalJSON); err != nil {
+		t.Fatalf("save original segments: %v", err)
+	}
+
+	// Edit segment bounds from [1.0, 2.0] to [2.0, 4.0] (stretched 2x, shifted +1.0)
+	edited := []transcriber.Segment{
+		{Start: 2.0, End: 4.0, Text: "hello world"},
+	}
+	saved, err := store.SaveSegments(id, edited)
+	if err != nil {
+		t.Fatalf("save segments: %v", err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("expected 1 segment, got %d", len(saved))
+	}
+	if len(saved[0].Words) != 2 {
+		t.Fatalf("expected 2 rescaled words, got %d", len(saved[0].Words))
+	}
+
+	// Original hello [1.1, 1.5] scaled into [2.0, 4.0] -> relative offset 0.1/1.0 = 10% -> 2.0 + 0.2 = 2.2
+	w0 := saved[0].Words[0]
+	if w0.Text != "hello" || w0.Start < 2.19 || w0.Start > 2.21 {
+		t.Errorf("word 0 start = %f, want ~2.2", w0.Start)
+	}
+}
+
+func TestRerenderVerifiesDoneStage(t *testing.T) {
+	nonDoneStages := []Stage{StageUploaded, StageTranscribing, StageRendering, StageFailed}
+	for _, stage := range nonDoneStages {
+		t.Run(string(stage), func(t *testing.T) {
+			store := newTestStoreWithPorts(t, &fakePublisher{}, &fakeCleaner{})
+			id := "job-" + string(stage)
+			createJobWithStage(t, store, id, stage)
+
+			_, err := store.Rerender(id)
+			if err == nil {
+				t.Fatalf("expected error for re-rendering stage %s, got nil", stage)
+			}
+			var conflictErr *StageConflictError
+			if !errors.As(err, &conflictErr) {
+				t.Fatalf("expected StageConflictError, got %T (%v)", err, err)
+			}
+			if conflictErr.Stage != stage {
+				t.Errorf("conflict error stage = %q, want %q", conflictErr.Stage, stage)
+			}
+		})
+	}
+}
+
+func TestRerenderPublishesFreshVfxJobAndTransitionsToRendering(t *testing.T) {
+	pub := &fakePublisher{}
+	cleaner := &fakeCleaner{}
+	store := newTestStoreWithPorts(t, pub, cleaner)
+	id := "u-rerender"
+	createJobWithStage(t, store, id, StageDone)
+
+	// Save segments and edit spec
+	segmentsJSON := `[{"start":1.0,"end":2.0,"text":"caption","words":[]}]`
+	if err := store.SaveOriginalSegments(id, segmentsJSON); err != nil {
+		t.Fatalf("save segments: %v", err)
+	}
+	specJSON := `{"trim":{"start":0,"end":10},"frame":{"preset":"9:16","ratio":0.5625,"zoom":1,"panX":0,"panY":0},"animation":"karaoke"}`
+	if err := store.SaveEditSpec(id, specJSON); err != nil {
+		t.Fatalf("save edit spec: %v", err)
+	}
+
+	proc, err := store.Rerender(id)
+	if err != nil {
+		t.Fatalf("rerender: %v", err)
+	}
+	if proc.Stage != StageRendering {
+		t.Errorf("process stage = %q, want %q", proc.Stage, StageRendering)
+	}
+
+	if len(pub.published) != 1 {
+		t.Fatalf("expected 1 published VFX job, got %d", len(pub.published))
+	}
+	job := pub.published[0]
+	if job.UploadID != id {
+		t.Errorf("published uploadID = %q, want %q", job.UploadID, id)
+	}
+	if job.ObjectKey != "uploads/"+id {
+		t.Errorf("published objectKey = %q, want %q", job.ObjectKey, "uploads/"+id)
+	}
+	if len(job.Segments) != 1 || job.Segments[0].Text != "caption" {
+		t.Errorf("unexpected published segments: %+v", job.Segments)
+	}
+	if job.EditSpec == nil || job.EditSpec.Animation != "karaoke" {
+		t.Errorf("unexpected published edit spec: %+v", job.EditSpec)
+	}
+}
+
+func TestRerenderRollsBackToFailedOnPublishError(t *testing.T) {
+	publishErr := errors.New("rabbitmq down")
+	pub := &fakePublisher{err: publishErr}
+	cleaner := &fakeCleaner{}
+	store := newTestStoreWithPorts(t, pub, cleaner)
+	id := "u-rerender-fail"
+	createJobWithStage(t, store, id, StageDone)
+
+	specJSON := `{"trim":{"start":0,"end":10},"frame":{"preset":"9:16","ratio":0.5625,"zoom":1,"panX":0,"panY":0},"animation":"karaoke"}`
+	if err := store.SaveEditSpec(id, specJSON); err != nil {
+		t.Fatalf("save edit spec: %v", err)
+	}
+
+	_, err := store.Rerender(id)
+	if err == nil {
+		t.Fatal("expected error on failed publish, got nil")
+	}
+	if !strings.Contains(err.Error(), "rabbitmq down") {
+		t.Errorf("expected error to mention rabbitmq down, got %v", err)
+	}
+
+	// Verify the process was rolled back to failed
+	p, getErr := store.Get(id)
+	if getErr != nil {
+		t.Fatalf("get: %v", getErr)
+	}
+	if p.Stage != StageFailed {
+		t.Errorf("process stage = %q, want %q", p.Stage, StageFailed)
+	}
+	if !strings.Contains(p.Reason, "rabbitmq down") {
+		t.Errorf("process reason = %q, want it to contain rabbitmq down", p.Reason)
+	}
+}
+
+func TestDeleteRemovesDatabaseRowsThenCleansObjectsBestEffort(t *testing.T) {
+	cleaner := &fakeCleaner{}
+	store := newTestStoreWithPorts(t, &fakePublisher{}, cleaner)
+	id := "u-delete"
+	createJobWithStage(t, store, id, StageDone)
+
+	segmentsJSON := `[{"start":1.0,"end":2.0,"text":"caption","words":[]}]`
+	if err := store.SaveOriginalSegments(id, segmentsJSON); err != nil {
+		t.Fatalf("save segments: %v", err)
+	}
+	specJSON := `{"animation":"karaoke"}`
+	if err := store.SaveEditSpec(id, specJSON); err != nil {
+		t.Fatalf("save edit spec: %v", err)
+	}
+
+	deleted, err := store.Delete(id)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected deleted=true")
+	}
+
+	// DB rows must be gone
+	if _, err := store.Get(id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound for deleted job, got %v", err)
+	}
+	if segs, _ := store.Segments(id); segs != "" {
+		t.Errorf("expected empty segments for deleted job, got %q", segs)
+	}
+	if spec, _ := store.EditSpec(id); spec != "" {
+		t.Errorf("expected empty edit spec for deleted job, got %q", spec)
+	}
+
+	// Cleaner must have been invoked for upload and output prefixes
+	wantCleaned := []string{"uploads/" + id, "outputs/" + id}
+	if len(cleaner.deleted) != 2 {
+		t.Fatalf("expected 2 deleted prefixes, got %d (%v)", len(cleaner.deleted), cleaner.deleted)
+	}
+	for i, want := range wantCleaned {
+		if cleaner.deleted[i] != want {
+			t.Errorf("cleaned[%d] = %q, want %q", i, cleaner.deleted[i], want)
+		}
+	}
+}
+
+func TestDeleteSucceedsEvenWhenObjectCleanerFails(t *testing.T) {
+	cleaner := &fakeCleaner{err: errors.New("s3 connection timeout")}
+	store := newTestStoreWithPorts(t, &fakePublisher{}, cleaner)
+	id := "u-delete-s3-fail"
+	createJobWithStage(t, store, id, StageDone)
+
+	deleted, err := store.Delete(id)
+	if err != nil {
+		t.Fatalf("delete must not fail when object cleaner errors: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected deleted=true")
+	}
+
+	// Row is still deleted despite cleaner failure
+	if _, err := store.Get(id); !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestRerenderNilPublisherDoesNotStrandJob(t *testing.T) {
+	// Constructing a store without a publisher is a configuration error, but
+	// it must not leave the process stranded in rendering — the check must
+	// fire before Reopen so the job stays done.
+	store := newTestStoreWithPorts(t, nil, &fakeCleaner{})
+	id := "u-nil-publisher"
+	createJobWithStage(t, store, id, StageDone)
+
+	_, err := store.Rerender(id)
+	if err == nil {
+		t.Fatal("expected error with nil publisher, got nil")
+	}
+
+	// Job must not have moved out of done
+	p, getErr := store.Get(id)
+	if getErr != nil {
+		t.Fatalf("get: %v", getErr)
+	}
+	if p.Stage != StageDone {
+		t.Errorf("stage = %q after nil-publisher rerender, want %q (must not strand in rendering)", p.Stage, StageDone)
+	}
+}

--- a/server/internal/processor/processor.go
+++ b/server/internal/processor/processor.go
@@ -143,7 +143,7 @@ func (p *Processor) ProcessUploadedFile(uploadID, objectKey string, spec *editsp
 	if p.lifecycle != nil {
 		if payload, err := json.Marshal(segments); err != nil {
 			log.Printf("[Processor] Failed to encode segments for upload %s: %v", uploadID, err)
-		} else if err := p.lifecycle.SaveSegments(uploadID, string(payload)); err != nil {
+		} else if err := p.lifecycle.SaveOriginalSegments(uploadID, string(payload)); err != nil {
 			log.Printf("[Processor] %v", err)
 		}
 		// Persist the original Edit Spec alongside, so a later re-render

--- a/server/internal/processor/processor_test.go
+++ b/server/internal/processor/processor_test.go
@@ -206,7 +206,7 @@ func (f *fakeLifecycle) MarkRendering(uploadID string) (bool, error) {
 	return true, nil
 }
 
-func (f *fakeLifecycle) SaveSegments(uploadID, segmentsJSON string) error {
+func (f *fakeLifecycle) SaveOriginalSegments(uploadID, segmentsJSON string) error {
 	if f.segments == nil {
 		f.segments = map[string]string{}
 	}

--- a/server/internal/transcriber/timing.go
+++ b/server/internal/transcriber/timing.go
@@ -1,0 +1,83 @@
+package transcriber
+
+import (
+	"fmt"
+	"math"
+)
+
+// TimingValidationError records a segment timing validation failure.
+type TimingValidationError struct {
+	Index  int    // 0-based index of the failing segment
+	Reason string // description of why the timing is invalid
+}
+
+func (e *TimingValidationError) Error() string {
+	return fmt.Sprintf("segment %d %s", e.Index+1, e.Reason)
+}
+
+// ValidationError is an alias for TimingValidationError for domain error matching.
+type ValidationError = TimingValidationError
+
+// ValidateSegmentTiming rejects edited segments the render cannot use:
+// non-finite times, negative starts, ends at or before their start, and
+// segments that start before the previous one ends (overlap or out of order).
+func ValidateSegmentTiming(segments []Segment) error {
+	for i, seg := range segments {
+		if !finiteTime(seg.Start) || !finiteTime(seg.End) {
+			return &TimingValidationError{
+				Index:  i,
+				Reason: "must carry finite start and end times",
+			}
+		}
+		if seg.Start < 0 {
+			return &TimingValidationError{
+				Index:  i,
+				Reason: "start must not be negative",
+			}
+		}
+		if seg.End <= seg.Start {
+			return &TimingValidationError{
+				Index:  i,
+				Reason: "end must be after its start",
+			}
+		}
+		if i > 0 && seg.Start < segments[i-1].End {
+			return &TimingValidationError{
+				Index:  i,
+				Reason: fmt.Sprintf("must not start before segment %d ends", i),
+			}
+		}
+	}
+	return nil
+}
+
+// RescaleWords keeps a segment's whisper-original word timings at their
+// relative offsets, scaled into the edited window. Word timings are never
+// re-derived from scratch; unchanged boundaries or degenerate original
+// windows leave words untouched.
+func RescaleWords(original, edited Segment) []Word {
+	if len(original.Words) == 0 {
+		return original.Words
+	}
+	if original.Start == edited.Start && original.End == edited.End {
+		return original.Words
+	}
+	span := original.End - original.Start
+	if span <= 0 {
+		return original.Words
+	}
+	targetSpan := edited.End - edited.Start
+	words := make([]Word, len(original.Words))
+	for i, w := range original.Words {
+		words[i] = Word{
+			Text:  w.Text,
+			Start: edited.Start + (w.Start-original.Start)/span*targetSpan,
+			End:   edited.Start + (w.End-original.Start)/span*targetSpan,
+		}
+	}
+	return words
+}
+
+func finiteTime(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}

--- a/server/internal/transcriber/timing_test.go
+++ b/server/internal/transcriber/timing_test.go
@@ -1,0 +1,274 @@
+package transcriber
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestValidateSegmentTimingValidSequences(t *testing.T) {
+	cases := []struct {
+		name     string
+		segments []Segment
+	}{
+		{
+			name:     "empty slice",
+			segments: []Segment{},
+		},
+		{
+			name: "single valid segment",
+			segments: []Segment{
+				{Start: 0.0, End: 2.5, Text: "hello"},
+			},
+		},
+		{
+			name: "multiple strictly chronological segments",
+			segments: []Segment{
+				{Start: 0.0, End: 1.5, Text: "first"},
+				{Start: 1.5, End: 3.0, Text: "second touching"},
+				{Start: 4.0, End: 5.5, Text: "third with gap"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateSegmentTiming(tc.segments); err != nil {
+				t.Fatalf("expected nil error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateSegmentTimingRejections(t *testing.T) {
+	cases := []struct {
+		name          string
+		segments      []Segment
+		expectedIndex int
+		reasonSubstr  string
+	}{
+		{
+			name: "NaN start",
+			segments: []Segment{
+				{Start: math.NaN(), End: 2.0},
+			},
+			expectedIndex: 0,
+			reasonSubstr:  "finite",
+		},
+		{
+			name: "Inf start",
+			segments: []Segment{
+				{Start: math.Inf(1), End: 2.0},
+			},
+			expectedIndex: 0,
+			reasonSubstr:  "finite",
+		},
+		{
+			name: "NaN end",
+			segments: []Segment{
+				{Start: 1.0, End: math.NaN()},
+			},
+			expectedIndex: 0,
+			reasonSubstr:  "finite",
+		},
+		{
+			name: "Inf end",
+			segments: []Segment{
+				{Start: 1.0, End: math.Inf(-1)},
+			},
+			expectedIndex: 0,
+			reasonSubstr:  "finite",
+		},
+		{
+			name: "negative start",
+			segments: []Segment{
+				{Start: -0.1, End: 2.0},
+			},
+			expectedIndex: 0,
+			reasonSubstr:  "negative",
+		},
+		{
+			name: "end equal to start",
+			segments: []Segment{
+				{Start: 1.0, End: 1.0},
+			},
+			expectedIndex: 0,
+			reasonSubstr:  "end must be after its start",
+		},
+		{
+			name: "end before start",
+			segments: []Segment{
+				{Start: 2.0, End: 1.0},
+			},
+			expectedIndex: 0,
+			reasonSubstr:  "end must be after its start",
+		},
+		{
+			name: "second segment starts before first ends (overlap)",
+			segments: []Segment{
+				{Start: 0.0, End: 2.0},
+				{Start: 1.9, End: 3.0},
+			},
+			expectedIndex: 1,
+			reasonSubstr:  "must not start before segment 1 ends",
+		},
+		{
+			name: "second segment out of order",
+			segments: []Segment{
+				{Start: 3.0, End: 5.0},
+				{Start: 1.0, End: 2.0},
+			},
+			expectedIndex: 1,
+			reasonSubstr:  "must not start before segment 1 ends",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateSegmentTiming(tc.segments)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+
+			var valErr *TimingValidationError
+			if !errors.As(err, &valErr) {
+				t.Fatalf("expected error to be *TimingValidationError, got %T (%v)", err, err)
+			}
+
+			if valErr.Index != tc.expectedIndex {
+				t.Errorf("expected segment index %d, got %d", tc.expectedIndex, valErr.Index)
+			}
+
+			if tc.reasonSubstr != "" && !contains(valErr.Error(), tc.reasonSubstr) {
+				t.Errorf("expected error message to contain %q, got %q", tc.reasonSubstr, valErr.Error())
+			}
+		})
+	}
+}
+
+func TestRescaleWordsProportional(t *testing.T) {
+	// Original window: 1.0 to 3.0 (span 2.0).
+	// Word 1: 1.2 to 1.6 (relative 0.2/2.0 = 10% to 0.6/2.0 = 30%)
+	// Word 2: 2.0 to 2.8 (relative 1.0/2.0 = 50% to 1.8/2.0 = 90%)
+	orig := Segment{
+		Start: 1.0,
+		End:   3.0,
+		Words: []Word{
+			{Text: "hello", Start: 1.2, End: 1.6},
+			{Text: "world", Start: 2.0, End: 2.8},
+		},
+	}
+
+	// Edited window: 2.0 to 6.0 (span 4.0).
+	// Expected word 1: 2.0 + 0.1 * 4.0 = 2.4 to 2.0 + 0.3 * 4.0 = 3.2
+	// Expected word 2: 2.0 + 0.5 * 4.0 = 4.0 to 2.0 + 0.9 * 4.0 = 5.6
+	edited := Segment{
+		Start: 2.0,
+		End:   6.0,
+	}
+
+	rescaled := RescaleWords(orig, edited)
+	if len(rescaled) != 2 {
+		t.Fatalf("expected 2 words, got %d", len(rescaled))
+	}
+
+	assertApprox(t, rescaled[0].Start, 2.4, "word 0 start")
+	assertApprox(t, rescaled[0].End, 3.2, "word 0 end")
+	assertApprox(t, rescaled[1].Start, 4.0, "word 1 start")
+	assertApprox(t, rescaled[1].End, 5.6, "word 1 end")
+	if rescaled[0].Text != "hello" || rescaled[1].Text != "world" {
+		t.Errorf("word texts mutated: %+v", rescaled)
+	}
+}
+func TestRescaleWordsShiftAndShrink(t *testing.T) {
+	orig := Segment{
+		Start: 10.0,
+		End:   20.0,
+		Words: []Word{
+			{Text: "first", Start: 11.0, End: 13.0}, // 10% to 30%
+			{Text: "second", Start: 15.0, End: 19.0}, // 50% to 90%
+		},
+	}
+
+	// Shifted by +5s with same duration (10s): 15.0 to 25.0
+	shifted := Segment{Start: 15.0, End: 25.0}
+	rescaledShift := RescaleWords(orig, shifted)
+	if len(rescaledShift) != 2 {
+		t.Fatalf("expected 2 words, got %d", len(rescaledShift))
+	}
+	assertApprox(t, rescaledShift[0].Start, 16.0, "shifted word 0 start")
+	assertApprox(t, rescaledShift[0].End, 18.0, "shifted word 0 end")
+	assertApprox(t, rescaledShift[1].Start, 20.0, "shifted word 1 start")
+	assertApprox(t, rescaledShift[1].End, 24.0, "shifted word 1 end")
+
+	// Shrunk to 5s: 10.0 to 15.0
+	shrunk := Segment{Start: 10.0, End: 15.0}
+	rescaledShrunk := RescaleWords(orig, shrunk)
+	if len(rescaledShrunk) != 2 {
+		t.Fatalf("expected 2 words, got %d", len(rescaledShrunk))
+	}
+	assertApprox(t, rescaledShrunk[0].Start, 10.5, "shrunk word 0 start")
+	assertApprox(t, rescaledShrunk[0].End, 11.5, "shrunk word 0 end")
+	assertApprox(t, rescaledShrunk[1].Start, 12.5, "shrunk word 1 start")
+	assertApprox(t, rescaledShrunk[1].End, 14.5, "shrunk word 1 end")
+}
+
+
+func TestRescaleWordsUnchangedBoundariesRetainTimestamps(t *testing.T) {
+	orig := Segment{
+		Start: 1.5,
+		End:   3.5,
+		Words: []Word{
+			{Text: "stay", Start: 1.8, End: 3.2},
+		},
+	}
+
+	edited := Segment{
+		Start: 1.5,
+		End:   3.5,
+		Text:  "edited text only",
+	}
+
+	rescaled := RescaleWords(orig, edited)
+	if len(rescaled) != 1 {
+		t.Fatalf("expected 1 word, got %d", len(rescaled))
+	}
+
+	if rescaled[0].Start != 1.8 || rescaled[0].End != 3.2 {
+		t.Errorf("expected unchanged timestamps (1.8, 3.2), got (%v, %v)", rescaled[0].Start, rescaled[0].End)
+	}
+}
+
+func TestRescaleWordsDegenerateOrEmpty(t *testing.T) {
+	// Empty words
+	origEmpty := Segment{Start: 1.0, End: 2.0, Words: nil}
+	editedEmpty := Segment{Start: 2.0, End: 4.0}
+	if res := RescaleWords(origEmpty, editedEmpty); len(res) != 0 {
+		t.Errorf("expected empty words, got %+v", res)
+	}
+
+	// Degenerate original span (end <= start)
+	origDegenerate := Segment{
+		Start: 2.0,
+		End:   2.0,
+		Words: []Word{{Text: "fixed", Start: 2.0, End: 2.0}},
+	}
+	edited := Segment{Start: 3.0, End: 5.0}
+	res := RescaleWords(origDegenerate, edited)
+	if len(res) != 1 || res[0].Start != 2.0 || res[0].End != 2.0 {
+		t.Errorf("expected degenerate words to be retained without division by zero, got %+v", res)
+	}
+}
+
+func assertApprox(t *testing.T, got, want float64, name string) {
+	t.Helper()
+	diff := got - want
+	if diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("%s = %v, want %v", name, got, want)
+	}
+}
+
+func contains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}


### PR DESCRIPTION
## Summary

Collapses Process lifecycle and transcript orchestration into a deep `internal/job` module, per spec #45.

- **#46**: Pure segment timing validation and word rescaling in `internal/transcriber`
- **#47**: Deepen `job.Store` with side-effect ports (`VfxPublisher`, `ObjectCleaner`), segment editing (`SaveSegments`), re-render coordination (`Rerender`), and deletion (`Delete`)
- **#48**: Collapse HTTP handler seam to `ProcessManager` and `OutputOpener`; migrate wiring in `main.go`

Closes #45
Closes #46
Closes #47
Closes #48